### PR TITLE
fix: Added support for php8.3 when checking dependencies during web-installation

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Facade;
 
 return [
 
-    'version' => '0.9.8',
+    'version' => '0.9.9',
 
     /*
     |--------------------------------------------------------------------------

--- a/public/install/functions.php
+++ b/public/install/functions.php
@@ -4,7 +4,7 @@ $required_extentions = ['openssl', 'gd', 'mysql', 'PDO', 'mbstring', 'tokenizer'
 
 $requirements = [
     'minPhp' => '8.1',
-    'maxPhp' => '8.2', // This version is not supported
+    'maxPhp' => '8.4', // This version is not supported
     'mysql' => '5.7.22',
 ];
 


### PR DESCRIPTION
Due to the fact that pterodactyl now recommends php8.3 for installation, we also have to switch to the php8.3 in order not to interfere with the operation of this two applications