### PR TITLE
Update server_limit logic when user makes a purchase

### DIFF
--- a/app/Listeners/UserPayment.php
+++ b/app/Listeners/UserPayment.php
@@ -14,7 +14,7 @@ use App\Settings\UserSettings;
 
 class UserPayment
 {
-    private $server_limit_after_irl_purchase;
+    private $server_limit_increment_after_irl_purchase;
 
     private $referral_mode;
 
@@ -37,7 +37,7 @@ class UserPayment
      */
     public function __construct(UserSettings $user_settings, ReferralSettings $referral_settings, GeneralSettings $general_settings, DiscordSettings $discord_settings)
     {
-        $this->server_limit_after_irl_purchase = $user_settings->server_limit_after_irl_purchase;
+        $this->server_limit_increment_after_irl_purchase = $user_settings->server_limit_increment_after_irl_purchase;
         $this->referral_mode = $referral_settings->mode;
         $this->referral_percentage = $referral_settings->percentage;
         $this->referral_always_give_commission = $referral_settings->always_give_commission;
@@ -65,10 +65,9 @@ class UserPayment
         }
 
         //update server limit
-        if ($this->server_limit_after_irl_purchase !== 0 && $user->server_limit < $this->server_limit_after_irl_purchase) {
-            $user->update(['server_limit' => $this->server_limit_after_irl_purchase]);
+        if ($this->server_limit_increment_after_irl_purchase !== 0 && $user->server_limit < $this->server_limit_increment_after_irl_purchase) {
+            $user->increment('server_limit', $this->server_limit_increment_after_irl_purchase);
         }
-
 
         //update User with bought item
         if ($shopProduct->type == "Credits") {

--- a/app/Settings/UserSettings.php
+++ b/app/Settings/UserSettings.php
@@ -15,9 +15,9 @@ class UserSettings extends Settings
     public float $initial_credits;
     public int $initial_server_limit;
     public float $min_credits_to_make_server;
-    public int $server_limit_after_irl_purchase;
-    public int $server_limit_after_verify_discord;
-    public int $server_limit_after_verify_email;
+    public int $server_limit_increment_after_irl_purchase;
+    public int $server_limit_increment_after_verify_discord;
+    public int $server_limit_increment_after_verify_email;
 
     public static function group(): string
     {
@@ -38,9 +38,9 @@ class UserSettings extends Settings
             'initial_credits' => 'required|numeric',
             'initial_server_limit' => 'required|numeric',
             'min_credits_to_make_server' => 'required|numeric',
-            'server_limit_after_irl_purchase' => 'required|numeric',
-            'server_limit_after_verify_discord' => 'required|numeric',
-            'server_limit_after_verify_email' => 'required|numeric',
+            'server_limit_increment_after_irl_purchase' => 'required|numeric',
+            'server_limit_increment_after_verify_discord' => 'required|numeric',
+            'server_limit_increment_after_verify_email' => 'required|numeric',
             'register_ip_check' => 'nullable|string',
             'creation_enabled' => 'nullable|string',
         ];
@@ -90,17 +90,17 @@ class UserSettings extends Settings
                 'type' => 'number',
                 'description' => 'The minimum amount of credits a user needs to create a server.',
             ],
-            'server_limit_after_irl_purchase' => [
-                'label' => 'Server Limit After first purchase',
+            'server_limit_increment_after_irl_purchase' => [
+                'label' => 'Server Limit Increase After first purchase',
                 'type' => 'number',
-                'description' => 'The amount of servers a user can create after they make their first purchase.',
+                'description' => 'Specifies how many additional servers a user can create after making their first purchase.',
             ],
-            'server_limit_after_verify_discord' => [
+            'server_limit_increment_after_verify_discord' => [
                 'label' => 'Server Limit Increase After Verify Discord',
                 'type' => 'number',
                 'description' => 'Specifies how many additional servers a user can create after verifying their Discord account.',
             ],
-            'server_limit_after_verify_email' => [
+            'server_limit_increment_after_verify_email' => [
                 'label' => 'Server Limit Increase After Verify Email',
                 'type' => 'number',
                 'description' => 'Specifies how many additional servers a user can create after verifying their email address.',

--- a/database/settings/2025_01_07_233254_update_variables_user_settings.php
+++ b/database/settings/2025_01_07_233254_update_variables_user_settings.php
@@ -1,0 +1,20 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->rename('user.server_limit_after_irl_purchase', 'user.server_limit_increment_after_irl_purchase');
+        $this->migrator->rename('user.server_limit_after_verify_discord', 'user.server_limit_increment_after_verify_discord');
+        $this->migrator->rename('user.server_limit_after_verify_email', 'user.server_limit_increment_after_verify_email');
+    }
+
+    public function down(): void
+    {
+        $this->migrator->rename('user.server_limit_increment_after_irl_purchase', 'user.server_limit_after_irl_purchase');
+        $this->migrator->rename('user.server_limit_increment_after_verify_discord', 'user.server_limit_after_verify_discord');
+        $this->migrator->rename('user.server_limit_increment_after_verify_email', 'user.server_limit_after_verify_email');
+    }
+};


### PR DESCRIPTION
This PR changes the behavior when the user makes a purchase and needs to have their `server_limit` changed.
Before, `server_limit` was changed completely without incrementing it.
Now it is incremented.
Also adjusted the variable names to match better.