### PR TITLE
Don't create hundreds of logs about credit updates or server limits.

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -329,7 +329,7 @@ class User extends Authenticatable implements MustVerifyEmail
         return LogOptions::defaults()
             ->logOnly(['role', 'name', 'server_limit', 'pterodactyl_id', 'email', 'credits', 'server_limit', 'suspended', 'referral_code'])
             ->logOnlyDirty()
-            ->dontSubmitEmptyLogs();
+            ->dontSubmitEmptyLogs()
+            ->dontLogIfAttributesChangedOnly(['credits', 'server_limit']);
     }
-
 }


### PR DESCRIPTION
Fixes #1153 
This PR basically no longer logs users' credit decrement or server_limit.
This is really worrying when you have a lot of users, and have products that charge by the hour.
This results in a lot of logs per hour.