### PR TITLE
Fix discord id searching in users table

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -381,7 +381,7 @@ class UserController extends Controller
      */
     public function dataTable(Request $request)
     {
-        $query = User::query()
+        $query = User::with('discordUser')
             ->withCount('servers')
             ->leftJoin('model_has_roles', 'users.id', '=', 'model_has_roles.model_id')
             ->leftJoin('roles', 'model_has_roles.role_id', '=', 'roles.id')
@@ -398,12 +398,9 @@ class UserController extends Controller
             ->addColumn('verified', function (User $user) {
                 return $user->getVerifiedStatus();
             })
-            /*  This broke the ability to search the table. Have to revisit later
-
             ->addColumn('discordId', function (User $user) {
                 return $user->discordUser ? $user->discordUser->id : '';
             })
-            */
             ->addColumn('actions', function (User $user) {
                 $suspendColor = $user->isSuspended() ? 'btn-success' : 'btn-warning';
                 $suspendIcon = $user->isSuspended() ? 'fa-play-circle' : 'fa-pause-circle';

--- a/themes/default/views/admin/users/index.blade.php
+++ b/themes/default/views/admin/users/index.blade.php
@@ -39,7 +39,7 @@
                     <table id="datatable" class="table table-striped">
                         <thead>
                         <tr>
-                          <!--  <th>discordId</th> -->
+                            <th>discordId</th>
                             <th>ip</th>
                             <th>pterodactyl_id</th>
                             <th>{{__('Avatar')}}</th>
@@ -85,14 +85,11 @@
                     [11, "desc"]
                 ],
                 columns: [
-                  /* This broke the ability to search the table. Have to revisit later
-                  {
+                    {
                         data: 'discordId',
                         visible: false,
                         name: 'discordUser.id'
                     },
-                    */
-
                     {
                         data: 'pterodactyl_id',
                         visible: false


### PR DESCRIPTION
💡 **Description**

Fixes/adds back searching using discord id in the users table in the administration

---

🛠️ **Type of Change**

- Bug fix (non-breaking change which fixes an issue)

---

🖼️ **Screenshots (if applicable)**

