### PR TITLE
Fix datatables styles, remove duplicated code

### DIFF
--- a/themes/BlueInfinity/views/layouts/main.blade.php
+++ b/themes/BlueInfinity/views/layouts/main.blade.php
@@ -24,7 +24,7 @@
 
     {{--
     <link rel="stylesheet" href="{{asset('css/adminlte.min.css')}}"> --}}
-    <link rel="stylesheet" href="{{ asset('plugins/datatables/jquery.dataTables.min.css') }}">
+    <link rel="stylesheet" href="{{ asset('plugins/datatables-bs4/css/dataTables.bootstrap4.min.css') }}">
 
     {{-- summernote --}}
     <link rel="stylesheet" href="{{ asset('plugins/summernote/summernote-bs4.min.css') }}">
@@ -526,6 +526,7 @@
     <script src="{{ asset('plugins/sweetalert2/sweetalert2.all.min.js') }}"></script>
 
     <script src="{{ asset('plugins/datatables/jquery.dataTables.min.js') }}"></script>
+    <script src="{{ asset('plugins/datatables-bs4/js/dataTables.bootstrap4.min.js') }}"></script>
     <!-- Summernote -->
     <script src="{{ asset('plugins/summernote/summernote-bs4.min.js') }}"></script>
     <!-- select2 -->

--- a/themes/default/views/admin/servers/index.blade.php
+++ b/themes/default/views/admin/servers/index.blade.php
@@ -35,79 +35,11 @@
                     </div>
                 </div>
                 <div class="card-body table-responsive">
-                    <table id="datatable" class="table table-striped">
-                        <thead>
-                            <tr>
-                                <th width="20">{{ __('Status') }}</th>
-                                <th>{{ __('Name') }}</th>
-                                <th>{{ __('User') }}</th>
-                                <th>{{ __('Server id') }}</th>
-                                <th>{{ __('Product') }}</th>
-                                <th>{{ __('Suspended at') }}</th>
-                                <th>{{ __('Created at') }}</th>
-                                <th>{{ __('Actions') }}</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        </tbody>
-                    </table>
+                    @include('admin.servers.table')
                 </div>
             </div>
         </div>
         <!-- END CUSTOM CONTENT -->
-        </div>
     </section>
     <!-- END CONTENT -->
 @endsection
-
-<script>
-    function submitResult() {
-        return confirm("{{ __('Are you sure you wish to delete?') }}") !== false;
-    }
-
-    document.addEventListener("DOMContentLoaded", function() {
-        $('#datatable').DataTable({
-            language: {
-                url: '//cdn.datatables.net/plug-ins/1.11.3/i18n/{{ $locale_datatables }}.json'
-            },
-            processing: true,
-            serverSide: true,
-            stateSave: true,
-            ajax: "{{ route('admin.servers.datatable') }}{{ $filter ?? '' }}",
-            order: [
-                [5, "desc"]
-            ],
-            columns: [{
-                    data: 'status',
-                    name: 'servers.suspended'
-                },
-                {
-                    data: 'name'
-                },
-                {
-                    data: 'user',
-                    name: 'user.name'
-                },
-                {
-                    data: 'identifier'
-                },
-                {
-                    data: 'product.name',
-                },
-                {
-                    data: 'suspended'
-                },
-                {
-                    data: 'created_at'
-                },
-                {
-                    data: 'actions',
-                    sortable: false
-                },
-            ],
-            fnDrawCallback: function(oSettings) {
-                $('[data-toggle="popover"]').popover();
-            }
-        });
-    });
-</script>

--- a/themes/default/views/admin/servers/table.blade.php
+++ b/themes/default/views/admin/servers/table.blade.php
@@ -5,7 +5,7 @@
             <th>{{ __('Name') }}</th>
             <th>{{ __('User') }}</th>
             <th>{{ __('Server id') }}</th>
-            <th>{{ __('Config') }}</th>
+            <th>{{ __('Product') }}</th>
             <th>{{ __('Suspended at') }}</th>
             <th>{{ __('Created at') }}</th>
             <th></th>

--- a/themes/default/views/admin/users/show.blade.php
+++ b/themes/default/views/admin/users/show.blade.php
@@ -255,22 +255,7 @@
                     <h5 class="card-title"><i class="fas fa-server mr-2"></i>{{ __('Servers') }}</h5>
                 </div>
                 <div class="card-body table-responsive">
-                    <table id="datatable" class="table table-striped">
-                        <thead>
-                            <tr>
-                                <th width="20"></th>
-                                <th>{{ __('Name') }}</th>
-                                <th>{{ __('User') }}</th>
-                                <th>{{ __('Server id') }}</th>
-                                <th>{{ __('Config') }}</th>
-                                <th>{{ __('Suspended at') }}</th>
-                                <th>{{ __('Created at') }}</th>
-                                <th></th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        </tbody>
-                    </table>
+                    @include('admin.servers.table', ['filter' => '?user=' . $user->id])
                 </div>
 
             </div>
@@ -312,52 +297,3 @@
     </section>
     <!-- END CONTENT -->
 @endsection
-
-<script>
-    document.addEventListener("DOMContentLoaded", function() {
-        $('#datatable').DataTable({
-            language: {
-                url: '//cdn.datatables.net/plug-ins/1.11.3/i18n/{{ $locale_datatables }}.json'
-            },
-            processing: true,
-            serverSide: true,
-            stateSave: true,
-            ajax: "{{ route('admin.servers.datatable') }}?user={{ $user->id }}",
-            order: [
-                [5, "desc"]
-            ],
-            columns: [{
-                    data: 'status',
-                    name: 'servers.suspended'
-                },
-                {
-                    data: 'name'
-                },
-                {
-                    data: 'user',
-                    name: 'user.name'
-                },
-                {
-                    data: 'identifier'
-                },
-                {
-                    data: 'resources',
-                    name: 'product.name'
-                },
-                {
-                    data: 'suspended'
-                },
-                {
-                    data: 'created_at'
-                },
-                {
-                    data: 'actions',
-                    sortable: false
-                },
-            ],
-            fnDrawCallback: function(oSettings) {
-                $('[data-toggle="popover"]').popover();
-            }
-        });
-    });
-</script>

--- a/themes/default/views/layouts/main.blade.php
+++ b/themes/default/views/layouts/main.blade.php
@@ -22,7 +22,7 @@
     <script src="{{ asset('plugins/alpinejs/3.12.0_cdn.min.js') }}" defer></script>
 
     {{-- <link rel="stylesheet" href="{{asset('css/adminlte.min.css')}}"> --}}
-    <link rel="stylesheet" href="{{ asset('plugins/datatables/jquery.dataTables.min.css') }}">
+    <link rel="stylesheet" href="{{ asset('plugins/datatables-bs4/css/dataTables.bootstrap4.min.css') }}">
 
     {{-- summernote --}}
     <link rel="stylesheet" href="{{ asset('plugins/summernote/summernote-bs4.min.css') }}">
@@ -531,6 +531,7 @@
     <script src="{{ asset('plugins/sweetalert2/sweetalert2.all.min.js') }}"></script>
 
     <script src="{{ asset('plugins/datatables/jquery.dataTables.min.js') }}"></script>
+    <script src="{{ asset('plugins/datatables-bs4/js/dataTables.bootstrap4.min.js') }}"></script>
     <!-- Summernote -->
     <script src="{{ asset('plugins/summernote/summernote-bs4.min.js') }}"></script>
     <!-- select2 -->


### PR DESCRIPTION
💡 **Description**

Fixes datatable styles by using the datatables bootstrap styles. Removes the duplicated code for servers datatable and uses include instead where it is needed.

---

🛠️ **Type of Change**

- User interface (UI) improvement

---

🖼️ **Screenshots (if applicable)**

Before:
![a](https://github.com/user-attachments/assets/87644844-dc73-4c73-938f-ee46fd9e2a2a)
![a](https://github.com/user-attachments/assets/e8916c9b-453b-4b21-9e32-c13fa40f09dc)

After:
![a](https://github.com/user-attachments/assets/7e192ea4-76ce-4389-b02b-e91adc817f79)
![a](https://github.com/user-attachments/assets/15a05407-bdba-4306-b2d3-1c859398c8b2)

