### PR TITLE
Don't show no nodes alert while loading

### DIFF
--- a/themes/default/views/servers/create.blade.php
+++ b/themes/default/views/servers/create.blade.php
@@ -152,7 +152,7 @@
                                   </template>
                                 </select>
                               </div>
-                              <div class="p-2 m-2 alert alert-danger" x-show="selectedProduct != null && selectedProduct != '' && locations.length == 0">
+                              <div class="p-2 m-2 alert alert-danger" style="display: none" x-show="selectedProduct != null && selectedProduct != '' && locations.length == 0 && !loading">
                                 {{ __('There seem to be no nodes available for this specification. Admins have been notified. Please try again later of contact us.') }}
                               </div>
                         </div>

--- a/themes/default/views/servers/create.blade.php
+++ b/themes/default/views/servers/create.blade.php
@@ -152,8 +152,8 @@
                                   </template>
                                 </select>
                               </div>
-                              <template x-if="true">
-                                <div class="p-2 m-2 alert alert-danger" x-show="selectedProduct != null && selectedProduct != '' && locations.length == 0 && !loading">
+                              <template x-if="selectedProduct != null && selectedProduct != '' && locations.length == 0 && !loading">
+                                <div class="p-2 m-2 alert alert-danger">
                                   {{ __('There seem to be no nodes available for this specification. Admins have been notified. Please try again later of contact us.') }}
                                 </div>
                               </template>

--- a/themes/default/views/servers/create.blade.php
+++ b/themes/default/views/servers/create.blade.php
@@ -152,7 +152,7 @@
                                   </template>
                                 </select>
                               </div>
-                              <div class="p-2 m-2 alert alert-danger" style="display: none" x-show="selectedProduct != null && selectedProduct != '' && locations.length == 0 && !loading">
+                              <div class="p-2 m-2 alert alert-danger d-none" x-show="selectedProduct != null && selectedProduct != '' && locations.length == 0 && !loading">
                                 {{ __('There seem to be no nodes available for this specification. Admins have been notified. Please try again later of contact us.') }}
                               </div>
                         </div>

--- a/themes/default/views/servers/create.blade.php
+++ b/themes/default/views/servers/create.blade.php
@@ -152,9 +152,11 @@
                                   </template>
                                 </select>
                               </div>
-                              <div class="p-2 m-2 alert alert-danger d-none" x-show="selectedProduct != null && selectedProduct != '' && locations.length == 0 && !loading">
-                                {{ __('There seem to be no nodes available for this specification. Admins have been notified. Please try again later of contact us.') }}
-                              </div>
+                              <template x-if="true">
+                                <div class="p-2 m-2 alert alert-danger" x-show="selectedProduct != null && selectedProduct != '' && locations.length == 0 && !loading">
+                                  {{ __('There seem to be no nodes available for this specification. Admins have been notified. Please try again later of contact us.') }}
+                                </div>
+                              </template>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
💡 **Description**

Fixes no nodes alert showing while the products are loading. Fixes no nodes alert showing while the page is loading by adding d-none class

---

🛠️ **Type of Change**

- User interface (UI) improvement

---

🖼️ **Screenshots (if applicable)**

Before:
https://github.com/user-attachments/assets/c7dbbf9b-24a0-42df-85f5-9201bc8f947a

After:
https://github.com/user-attachments/assets/061357d0-b823-4a82-928a-058c313e2bc3