### PR TITLE
fix: servers not deleting on creation failure

### DIFF
--- a/app/Classes/PterodactylClient.php
+++ b/app/Classes/PterodactylClient.php
@@ -296,10 +296,6 @@ class PterodactylClient
                 ],
             ]);
 
-            if ($response->failed()) {
-                throw self::getException('Failed to create server on pterodactyl', $response->status());
-            }
-
             return $response;
         } catch (Exception $e) {
             throw $e;


### PR DESCRIPTION
💡 **Description**

Fixes servers not being deleted when the creation fails on pterodactyl by removing exception throw in `PterodactylClient` since the check for response is in `ServerController`.

---

🛠️ **Type of Change**

- Bug fix (non-breaking change which fixes an issue)