### PR TITLE
Fix discord server join

### DIFF
--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -69,7 +69,10 @@ class SocialiteController extends Controller
                         'Authorization' => 'Bot '. $botToken,
                         'Content-Type' => 'application/json',
                     ]
-                )->put("https://discord.com/api/guilds/{$guildId}/members/{$discord->id}");
+                )->put(
+                    "https://discord.com/api/guilds/{$guildId}/members/{$discord->id}",
+                    ['access_token' => $discord->token]
+                );
 
                 if ($response->failed()) {
                     throw new Exception(


### PR DESCRIPTION
💡 **Description**

Fixes discord server joining on discord account connection. Fixes #1207 and #1212. The issue was introduced in #1173, it seems like Ferks did not test the joining after he removed the `access_token` field from the join request.

---

🛠️ **Type of Change**

- Bug fix (non-breaking change which fixes an issue)