### PR TITLE
fix: :bug: prevent error when discordUser is missing during role assignment

### DIFF
--- a/app/Listeners/UserPayment.php
+++ b/app/Listeners/UserPayment.php
@@ -115,7 +115,7 @@ class UserPayment implements ShouldQueue
         }
 
         //set discord role
-        if(!empty($this->bot_token) && $this->role_on_purchase && !empty($this->role_id_on_purchase)) {
+        if(!empty($this->bot_token) && $this->role_on_purchase && !empty($this->role_id_on_purchase) && !empty($user->discordUser)) {
             $discordUser = $user->discordUser;
             $success = $discordUser->addOrRemoveRole('add', $this->role_id_on_purchase);
 


### PR DESCRIPTION
💡 **Description**

Added a check to ensure `discordUser` exists before attempting to assign a Discord role. Previously, the code could throw an error if the user didn’t have an associated `discordUser`.

---

🛠️ **Type of Change**

- Bug fix
