### PR TITLE
Fix composer warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,10 @@
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        }
+        },
+        "exclude-from-classmap": [
+            "app/Extensions/PaymentGateways/**/migrations"
+        ]
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
Just ignore migrations from payment gateways, this fixes composer's PSR-4 warnings.