### PR TITLE
Dash cache invalidation fix: Fixes #1277 Issue

### DIFF
--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -28,6 +28,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Request as FacadesRequest;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Enum;
+use Illuminate\Support\Facades\Cache;
 
 class ServerController extends Controller
 {
@@ -305,6 +306,7 @@ class ServerController extends Controller
 
         $user->decrement('credits', $server->product->price);
 
+        Cache::forget('user_credits_left:' . $user->id);
         try {
             if ($this->discordSettings->role_for_active_clients &&
                 $user->discordUser &&
@@ -362,6 +364,7 @@ class ServerController extends Controller
         }
 
         $server->delete();
+        Cache::forget('user_credits_left:' . $server->user_id);
     }
 
     public function cancel(Server $server): RedirectResponse


### PR DESCRIPTION
This PR fixes the 500 Server Error issue on the dashboard of a admin-impersonated account after creating a server
Issue: #1277 
### Root Cause:
* Dashboard’s credit runout calculation (“time left” box) is cached per user for 5 minutes.
* When an admin impersonates a user with no servers and creates one:
  * Cache is initialized with `null timeLeft` (since no servers existed initially).
  * Server creation deducts credits and adds a server without clearing the cache.
* When the actual user logs back in:
  * Dashboard detects usage > 0 but still reads the stale `null timeLeft` from cache.
  * This causes the view to attempt array access on null, triggering a 500 error.
* Fix implemented: added `Cache::forget` in `handlePostCreation` and `handleServerDeletion` to invalidate the cache whenever server count or credits change.

###  Steps admins need to take after implementing this fix:
 - run `php artisan view:clear && php artisan cache:clear`
