### PR TITLE
🔨feat: Add Currency Format Customization and Locale-Based Format Derivation

### DIFF
--- a/app/Helpers/CurrencyHelper.php
+++ b/app/Helpers/CurrencyHelper.php
@@ -11,9 +11,35 @@ class CurrencyHelper
         return $amount / 1000;
     }
 
-    public function formatForDisplay($amount, $decimals = 2)
+    public function formatForDisplay($amount, $decimals = 2, $locale = null, $ignoreOverride = false)
     {
-        return number_format($this->convertForDisplay($amount), $decimals, ',', '.');
+        $locale = $locale ?: str_replace('_', '-', app()->getLocale());
+
+        if (!$ignoreOverride) {
+            $override = resolve(\App\Settings\GeneralSettings::class)->currency_format_override ?? null;
+            if ($override) {
+                $locale = $override;
+            }
+        }
+
+        $display = $this->convertForDisplay($amount);
+
+        if ($locale === 'bg' && $display <= 9999) {
+            return number_format($display, $decimals, ',', '');
+        }
+
+        if ($locale === 'es' && $display < 10000) {
+            return number_format($display, $decimals, ',', '');
+        }
+
+        if ($locale === 'pl' && $display <= 9999) {
+            return number_format($display, $decimals, ',', '');
+        }
+
+        $formatter = new NumberFormatter($locale, NumberFormatter::DECIMAL);
+        $formatter->setAttribute(NumberFormatter::MIN_FRACTION_DIGITS, $decimals);
+        $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $decimals);
+        return $formatter->format($display);
     }
 
     public function formatForForm($amount, $decimals = 2)
@@ -29,6 +55,12 @@ class CurrencyHelper
     public function formatToCurrency(int $amount, $currency_code, $locale = null,)
     {
         $locale = $locale ?: str_replace('_', '-', app()->getLocale());
+
+        // overriding users locale with global override
+        $override = resolve(\App\Settings\GeneralSettings::class)->currency_format_override ?? null;
+        if ($override) {
+            $locale = $override;
+        }
 
         $formatter = new NumberFormatter($locale, NumberFormatter::CURRENCY);
 

--- a/app/Helpers/CurrencyHelper.php
+++ b/app/Helpers/CurrencyHelper.php
@@ -24,7 +24,7 @@ class CurrencyHelper
 
         if (!$ignoreOverride) {
             $override = resolve(\App\Settings\GeneralSettings::class)->currency_format_override ?? null;
-            if ($override && $override !== '') {
+            if ($override) {
                 $effectiveLocale = $override;
             }
         }
@@ -82,7 +82,7 @@ class CurrencyHelper
         return (int)($amount * 1000);
     }
 
-    public function formatToCurrency(int $amount, $currency_code, $locale = null,)
+    public function formatToCurrency(int $amount, $currency_code, $locale = null)
     {
         $locale = $this->getEffectiveLocale($locale, false);
 

--- a/app/Helpers/CurrencyHelper.php
+++ b/app/Helpers/CurrencyHelper.php
@@ -47,25 +47,13 @@ class CurrencyHelper
 
         $display = $this->convertForDisplay($amount);
 
-        // Bulgarian ('bg') locale: For numbers <= 9999, use comma as decimal separator and no thousands separator.
-        // This follows common Bulgarian formatting conventions for small numbers, as per CLDR and local usage.
+        // For Bulgarian ('bg'), Spanish ('es'), and Polish ('pl') locales: For numbers <= 9999, use comma as decimal separator and no thousands separator.
+        // This follows common formatting conventions for small numbers in these locales, as per CLDR and local usage.
         // source: https://forum.opencart.com/viewtopic.php?t=144907
-        if ($locale === 'bg' && $display <= 9999) {
+        $specialLocales = ['bg', 'es', 'pl'];
+        if (in_array($locale, $specialLocales, true) && $display <= 9999) {
             return number_format($display, $decimals, ',', '');
         }
-
-        // Spanish ('es') locale: For numbers <= 9999, use comma as decimal separator and no thousands separator.
-        // This matches Spanish formatting standards for small numbers, as seen in CLDR and government guidelines.
-        if ($locale === 'es' && $display <= 9999) {
-            return number_format($display, $decimals, ',', '');
-        }
-
-        // Polish ('pl') locale: For numbers <= 9999, use comma as decimal separator and no thousands separator.
-        // This reflects Polish conventions for small numbers, according to CLDR and local financial documents.
-        if ($locale === 'pl' && $display <= 9999) {
-            return number_format($display, $decimals, ',', '');
-        }
-
         $formatter = new NumberFormatter($locale, NumberFormatter::DECIMAL);
         $formatter->setAttribute(NumberFormatter::MIN_FRACTION_DIGITS, $decimals);
         $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $decimals);

--- a/app/Http/Controllers/PreferencesController.php
+++ b/app/Http/Controllers/PreferencesController.php
@@ -24,7 +24,8 @@ class PreferencesController extends Controller
         $generalSettings = $this->generalSettings;
 
         $currencyOverrideAlert = null;
-        if ($generalSettings->currency_format_override) {
+        // Only show alert when an override is actively set (non-empty string)
+        if ($generalSettings->currency_format_override && $generalSettings->currency_format_override !== '') {
             $currencyOverrideAlert = __('Global currency format override is enabled. All currency and number displays use :locale formatting. Your language preference does not affect currency formatting.', ['locale' => $generalSettings->currency_format_override]);
         }
 

--- a/app/Http/Controllers/PreferencesController.php
+++ b/app/Http/Controllers/PreferencesController.php
@@ -25,7 +25,7 @@ class PreferencesController extends Controller
 
         $currencyOverrideAlert = null;
         // Only show alert when an override is actively set (non-empty string)
-        if ($generalSettings->currency_format_override && $generalSettings->currency_format_override !== '') {
+        if (!empty($generalSettings->currency_format_override)) {
             $currencyOverrideAlert = __('Global currency format override is enabled. All currency and number displays use :locale formatting. Your language preference does not affect currency formatting.', ['locale' => $generalSettings->currency_format_override]);
         }
 

--- a/app/Http/Controllers/PreferencesController.php
+++ b/app/Http/Controllers/PreferencesController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Settings\GeneralSettings;
 use App\Settings\LocaleSettings;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Session;
@@ -9,17 +10,25 @@ use Illuminate\Support\Facades\Session;
 class PreferencesController extends Controller
 {
     private $localeSettings;
+    private $generalSettings;
 
-    public function __construct(LocaleSettings $localeSettings)
+    public function __construct(LocaleSettings $localeSettings, GeneralSettings $generalSettings)
     {
         $this->localeSettings = $localeSettings;
+        $this->generalSettings = $generalSettings;
     }
 
     public function index(Request $request)
     {
         $localeSettings = $this->localeSettings;
+        $generalSettings = $this->generalSettings;
 
-        return view('preferences.index', compact('localeSettings'));
+        $currencyOverrideAlert = null;
+        if ($generalSettings->currency_format_override) {
+            $currencyOverrideAlert = __('Global currency format override is enabled. All currency and number displays use :locale formatting. Your language preference does not affect currency formatting.', ['locale' => $generalSettings->currency_format_override]);
+        }
+
+        return view('preferences.index', compact('localeSettings', 'currencyOverrideAlert'));
     }
 
     public function update(Request $request)

--- a/app/Notifications/InvoiceNotification.php
+++ b/app/Notifications/InvoiceNotification.php
@@ -52,7 +52,7 @@ class InvoiceNotification extends Notification implements ShouldQueue
             ->line(__('Price').': '.Currency::formatToCurrency($this->payment->total_price, $this->payment->currency_code))
             ->line(__('Type').': '.$this->payment->type)
             ->line(__('Amount').': '.$this->payment->amount)
-            ->line(__('Balance').': '.number_format($this->user->credits, 2))
+            ->line(__('Balance').': '.Currency::formatForDisplay($this->user->credits))
             ->line(__('User ID').': '.$this->payment->user_id)
             ->attach(storage_path('app/invoice/'.$this->user->id.'/'.now()->format('Y').'/'.$this->invoice_file));
     }

--- a/app/Settings/GeneralSettings.php
+++ b/app/Settings/GeneralSettings.php
@@ -9,6 +9,7 @@ class GeneralSettings extends Settings
     public bool $store_enabled = false;
     public ?float $sales_tax = null;
     public string $credits_display_name = 'Credits';
+    public ?string $currency_format_override = 'en';
     public ?string $recaptcha_version = null;
     public ?string $recaptcha_site_key = null;
     public ?string $recaptcha_secret_key = null;
@@ -39,6 +40,7 @@ class GeneralSettings extends Settings
             'store_enabled' => 'nullable|string',
             'sales_tax' => 'nullable|numeric',
             'credits_display_name' => 'required|string',
+            'currency_format_override' => 'nullable|string|in:' . implode(',', array_merge([''], config('app.available_locales'))),
             'recaptcha_version' => 'nullable|string|in:v2,v3,turnstile',
             'recaptcha_site_key' => 'nullable|string',
             'recaptcha_secret_key' => 'nullable|string',
@@ -64,7 +66,20 @@ class GeneralSettings extends Settings
         return $themesWithLabels;
     }
 
+    public static function getCurrencyFormatOptions()
+    {
+        $options = [];
+        $locales = config('app.available_locales');
+        $helper = new \App\Helpers\CurrencyHelper();
 
+        foreach ($locales as $locale) {
+            // Format a sample amount (1234.56 in database units = 1234560)
+            $sample = $helper->formatForDisplay(1234560, 2, $locale);
+            $options[$locale] = "$locale: $sample";
+        }
+
+        return $options;
+    }
 
     /**
      * Summary of optionTypes
@@ -91,6 +106,13 @@ class GeneralSettings extends Settings
                 'type' => 'string',
                 'label' => 'Credits Display Name',
                 'description' => 'The name of the currency used.'
+            ],
+            'currency_format_override' => [
+                'type' => 'select',
+                'label' => 'Currency Format Override',
+                'description' => 'Force all currency displays to use this locale\'s formatting, overriding the current locale.',
+                'options' => array_merge(['' => 'Auto (Use Current Locale)'], self::getCurrencyFormatOptions()),
+                'identifier' => 'value'
             ],
             'recaptcha_version' => [
                 'type' => 'select',

--- a/app/Settings/GeneralSettings.php
+++ b/app/Settings/GeneralSettings.php
@@ -3,13 +3,13 @@
 namespace App\Settings;
 
 use Spatie\LaravelSettings\Settings;
-
+use App\Helpers\CurrencyHelper;
 class GeneralSettings extends Settings
 {
     public bool $store_enabled = false;
     public ?float $sales_tax = null;
     public string $credits_display_name = 'Credits';
-    public ?string $currency_format_override = 'en';
+    public ?string $currency_format_override = null;
     public ?string $recaptcha_version = null;
     public ?string $recaptcha_site_key = null;
     public ?string $recaptcha_secret_key = null;
@@ -70,11 +70,11 @@ class GeneralSettings extends Settings
     {
         $options = [];
         $locales = config('app.available_locales');
-        $helper = new \App\Helpers\CurrencyHelper();
+        $helper = app(CurrencyHelper::class);
 
         foreach ($locales as $locale) {
             // Format a sample amount (1234.56 in database units = 1234560)
-            $sample = $helper->formatForDisplay(1234560, 2, $locale);
+            $sample = $helper->formatForDisplay(1234560, 2, $locale, true);
             $options[$locale] = "$locale: $sample";
         }
 

--- a/database/settings/2025_10_29_102720_add_currency_format_override_to_general_settings.php
+++ b/database/settings/2025_10_29_102720_add_currency_format_override_to_general_settings.php
@@ -6,6 +6,6 @@ return new class extends SettingsMigration
 {
     public function up(): void
     {
-        $this->migrator->add('general.currency_format_override', 'en');
+        $this->migrator->add('general.currency_format_override', '');
     }
 };

--- a/database/settings/2025_10_29_102720_add_currency_format_override_to_general_settings.php
+++ b/database/settings/2025_10_29_102720_add_currency_format_override_to_general_settings.php
@@ -8,4 +8,9 @@ return new class extends SettingsMigration
     {
         $this->migrator->add('general.currency_format_override', '');
     }
+
+    public function down(): void
+    {
+        $this->migrator->delete('general.currency_format_override');
+    }
 };

--- a/database/settings/2025_10_29_102720_add_currency_format_override_to_general_settings.php
+++ b/database/settings/2025_10_29_102720_add_currency_format_override_to_general_settings.php
@@ -1,0 +1,11 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('general.currency_format_override', 'en');
+    }
+};

--- a/themes/default/views/preferences/index.blade.php
+++ b/themes/default/views/preferences/index.blade.php
@@ -6,11 +6,11 @@
         <div class="container-fluid">
             <div class="mb-2 row">
                 <div class="col-sm-6">
-                    <h1>{{__('Preferences')}}</h1>
+                    <h1>{{ __('Preferences') }}</h1>
                 </div>
                 <div class="col-sm-6">
                     <ol class="breadcrumb float-sm-right">
-                        <li class="breadcrumb-item"><a href="{{route('home')}}">{{__('Dashboard')}}</a></li>
+                        <li class="breadcrumb-item"><a href="{{ route('home') }}">{{ __('Dashboard') }}</a></li>
                     </ol>
                 </div>
             </div>
@@ -21,6 +21,13 @@
     <!-- MAIN CONTENT -->
     <section class="content">
         <div class="container-fluid">
+            @if ($currencyOverrideAlert)
+                <div class="alert alert-warning alert-dismissible">
+                    <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+                    <h5><i class="icon fas fa-exclamation-triangle"></i> {{ __('Currency Format Override') }}</h5>
+                    {{ $currencyOverrideAlert }}
+                </div>
+            @endif
             <!-- CUSTOM CONTENT -->
             <form method="post" action="{{ route('preferences.update') }}">
                 @csrf
@@ -28,18 +35,22 @@
                     <div class="col-md-12">
                         <div class="card">
                             <div class="card-header">
-                                <h3 class="card-title">{{__('Language')}}</h3>
+                                <h3 class="card-title">{{ __('Language') }}</h3>
                             </div>
                             <div class="card-body">
                                 <div class="form-group">
-                                    <label for="locale">{{__('Language')}}</label>
-                                    <select name="locale" id="locale" @if(!$localeSettings->clients_can_change) disabled @endif class="custom-select w-100">
+                                    <label for="locale">{{ __('Language') }}</label>
+                                    <select name="locale" id="locale" @if (!$localeSettings->clients_can_change) disabled @endif
+                                        class="custom-select w-100">
                                         @foreach (explode(',', $localeSettings->available) as $key)
-                                            <option value="{{ $key }}" @if(session('locale') == $key) selected @endif>{{ ucfirst($key) }}</option>
+                                            <option value="{{ $key }}"
+                                                @if (session('locale') == $key) selected @endif>{{ ucfirst($key) }}
+                                            </option>
                                         @endforeach
                                     </select>
-                                  @if(!$localeSettings->clients_can_change)
-                                    <small><i class="fas fa-info-circle"></i> {{__("Changing the locale has been disabled by the System-Admins")}}</small>
+                                    @if (!$localeSettings->clients_can_change)
+                                        <small><i class="fas fa-info-circle"></i>
+                                            {{ __('Changing the locale has been disabled by the System-Admins') }}</small>
                                     @endif
                                 </div>
                                 <div class="row">


### PR DESCRIPTION
## Multiple Currency Format Support and Locale-Based Format Derivation

### Summary
Adds locale-aware currency and number formatting with admin override controls and user alerts.

### Changes
- **CurrencyHelper**: Enhanced with locale support and special cases for bg/es/pl formatting
- **GeneralSettings**: New `currency_format_override` dropdown with live format previews
- **Settings Migration**: Initializes override setting with English default
- **Preferences Page**: Alert when global overrides are active

### Features
- 22+ locale support with CLDR-compliant formatting
- Special rules: Bulgarian/Spanish/Polish no-separator thresholds
- Admin can force uniform formatting across the app
- Users see clear alerts about override restrictions

### Testing
- All locales tested with edge cases
- Settings persistence verified
- Backward compatibility maintained

---
## Pictures 
### Default to user locale-based currency formatting
<img width="1168" height="191" alt="image" src="https://github.com/user-attachments/assets/55c8e0fe-bf55-418f-8afd-9fcd0ea530fb" />

### Use Global Override
<img width="872" height="170" alt="image" src="https://github.com/user-attachments/assets/d809b482-9755-48e5-a654-682274505b81" />
<img width="1666" height="576" alt="image" src="https://github.com/user-attachments/assets/91ae2c7c-fc3e-4d80-94ee-db7fdbcd2287" />

Much more concise and easier for admins as well as users!