### PR TITLE
🛠️bugfix: prevent referral system abuse by retaining deleted referrals to be shown for admins

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -120,7 +120,7 @@ class UserController extends Controller
                         ];
                     } else {
                         $allReferrals[] = (object)[
-                            'id' => null,
+                            'id' => 'N/A',
                             'name' => 'Unknown (deleted)',
                             'created_at' => \Carbon\Carbon::parse($referral->created_at),
                             'deleted' => true,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -135,8 +135,7 @@ class User extends Authenticatable implements MustVerifyEmail
             foreach ($referralRecords as $ref) {
                 // mark ref as deleted and persist the deleted user id and name
                 DB::table('user_referrals')
-                    ->where('referral_id', $ref->referral_id)
-                    ->where('registered_user_id', $ref->registered_user_id)
+                    ->where('id', $ref->id)
                     ->update([
                         'deleted_at' => now(),
                         'deleted_username' => $user->name,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -135,7 +135,8 @@ class User extends Authenticatable implements MustVerifyEmail
             foreach ($referralRecords as $ref) {
                 // mark ref as deleted and persist the deleted user id and name
                 DB::table('user_referrals')
-                    ->where('id', $ref->id)
+                    ->where('referral_id', $ref->referral_id)
+                    ->where('registered_user_id', $ref->registered_user_id)
                     ->update([
                         'deleted_at' => now(),
                         'deleted_username' => $user->name,

--- a/database/migrations/2025_10_30_054037_add_deleted_user_id_to_user_referrals.php
+++ b/database/migrations/2025_10_30_054037_add_deleted_user_id_to_user_referrals.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('user_referrals', function (Blueprint $table) {
+            $table->timestamp('deleted_at')->nullable();
+            $table->string('deleted_username')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('user_referrals', function (Blueprint $table) {
+            $table->dropColumn(['deleted_at', 'deleted_username']);
+        });
+    }
+};

--- a/database/migrations/2025_10_30_054037_add_deleted_user_id_to_user_referrals.php
+++ b/database/migrations/2025_10_30_054037_add_deleted_user_id_to_user_referrals.php
@@ -15,6 +15,7 @@ return new class extends Migration {
         Schema::table('user_referrals', function (Blueprint $table) {
             $table->timestamp('deleted_at')->nullable();
             $table->string('deleted_username')->nullable();
+            $table->unsignedBigInteger('deleted_user_id')->nullable();
         });
     }
 
@@ -26,7 +27,7 @@ return new class extends Migration {
     public function down()
     {
         Schema::table('user_referrals', function (Blueprint $table) {
-            $table->dropColumn(['deleted_at', 'deleted_username']);
+            $table->dropColumn(['deleted_at', 'deleted_username', 'deleted_user_id']);
         });
     }
 };

--- a/database/migrations/2025_10_30_054110_update_user_referrals_foreign_keys.php
+++ b/database/migrations/2025_10_30_054110_update_user_referrals_foreign_keys.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('user_referrals', function (Blueprint $table) {
+            $table->dropForeign(['referral_id']);
+            $table->dropForeign(['registered_user_id']);
+
+            $table->unsignedBigInteger('referral_id')->nullable()->change();
+            $table->unsignedBigInteger('registered_user_id')->nullable()->change();
+
+            //add back fks leaving the values of user id and referral id intact for referral abuse tracking
+            $table->foreign('referral_id')->references('id')->on('users')->onDelete('set null');
+            $table->foreign('registered_user_id')->references('id')->on('users')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('user_referrals', function (Blueprint $table) {
+            $table->dropForeign(['referral_id']);
+            $table->dropForeign(['registered_user_id']);
+            $table->unsignedBigInteger('referral_id')->nullable(false)->change();
+            $table->unsignedBigInteger('registered_user_id')->nullable(false)->change();
+            $table->foreign('referral_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('registered_user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+};

--- a/database/migrations/2025_10_30_054110_update_user_referrals_foreign_keys.php
+++ b/database/migrations/2025_10_30_054110_update_user_referrals_foreign_keys.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration {
     /**
@@ -35,6 +36,10 @@ return new class extends Migration {
         Schema::table('user_referrals', function (Blueprint $table) {
             $table->dropForeign(['referral_id']);
             $table->dropForeign(['registered_user_id']);
+
+            // Clean up any NULL values that may exist due to set null on delete
+            DB::table('user_referrals')->whereNull('referral_id')->orWhereNull('registered_user_id')->delete();
+
             $table->unsignedBigInteger('referral_id')->nullable(false)->change();
             $table->unsignedBigInteger('registered_user_id')->nullable(false)->change();
             $table->foreign('referral_id')->references('id')->on('users')->onDelete('cascade');

--- a/themes/default/views/admin/users/show.blade.php
+++ b/themes/default/views/admin/users/show.blade.php
@@ -268,23 +268,25 @@
 
 
                     @foreach ($referrals as $referral)
-                        <div class="col-lg-6">
-                            <div class="row">
-                                <div class="col-lg-4">
-                                    <label>User ID: {{ $referral->id }}</label>
-                                </div>
-                                <div class="col-lg-4">
-                                    <span style="max-width: 250px;" class="d-inline-block text-truncate">
-                                        <i class="mr-2 fas fa-user-check"></i><a
-                                            href="{{ route('admin.users.show', $referral->id) }}">{{ $referral->name }}</a>
-                                    </span>
-                                </div>
-                                <div class="col-lg-4">
-                                    <span style="max-width: 250px;" class="d-inline-block text-truncate">
-                                        <i class="mr-2 fas fa-clock"></i>{{ $referral->created_at->diffForHumans() }}
-                                    </span>
-                                </div>
-                            </div>
+                        <div class="row mb-3 align-items-center">
+                          <div class="col-md-4 col-sm-12 mb-1 mb-md-0">
+                            <label class="mb-0">User ID: {{ $referral->id ?? 'Deleted' }}</label>
+                          </div>
+                          <div class="col-md-4 col-sm-12 mb-1 mb-md-0">
+                            <span class="d-inline-block text-truncate" style="max-width:250px;">
+                              <i class="mr-2 fas fa-user-check"></i>
+                              @if ($referral->deleted ?? false)
+                                <span class="text-danger">{{ $referral->name }}</span>
+                              @else
+                                <a href="{{ route('admin.users.show', $referral->id) }}">{{ $referral->name }}</a>
+                              @endif
+                            </span>
+                          </div>
+                          <div class="col-md-4 col-sm-12">
+                            <span class="d-inline-block text-truncate" style="max-width:250px;">
+                              <i class="mr-2 fas fa-clock"></i>{{ \Carbon\Carbon::parse($referral->created_at)->diffForHumans() }}
+                            </span>
+                          </div>
                         </div>
                     @endforeach
                 </div>

--- a/themes/default/views/admin/users/show.blade.php
+++ b/themes/default/views/admin/users/show.blade.php
@@ -272,7 +272,11 @@
                     @foreach ($referrals as $referral)
                         <div class="row mb-3 align-items-center">
                             <div class="col-md-4 col-sm-12 mb-1 mb-md-0">
-                                <label class="mb-0">User ID: {{ $referral->id ?? 'N/A' }}</label>
+                                @if ($referral->deleted ?? false)
+                                    <label class="mb-0">Deleted User ID: {{ $referral->id ?? 'N/A' }}</label>
+                                @else
+                                    <label class="mb-0">User ID: {{ $referral->id }}</label>
+                                @endif
                             </div>
                             <div class="col-md-4 col-sm-12 mb-1 mb-md-0">
                                 <span class="d-inline-block text-truncate" style="max-width:250px;">

--- a/themes/default/views/admin/users/show.blade.php
+++ b/themes/default/views/admin/users/show.blade.php
@@ -75,7 +75,8 @@
                                 </div>
                                 <div class="col-lg-8">
                                     @foreach ($user->roles as $role)
-                                        <span style='background-color: {{$role->color}}' class='badge'>{{$role->name}}</span>
+                                        <span style='background-color: {{ $role->color }}'
+                                            class='badge'>{{ $role->name }}</span>
                                     @endforeach
                                 </div>
                             </div>
@@ -194,7 +195,8 @@
                                 </div>
                                 <div class="col-lg-8">
                                     <span style="max-width: 250px;" class="d-inline-block text-truncate">
-                                        <i class="mr-2 fas fa-coins"></i>{{ Currency::formatForDisplay($user->creditUsage()) }}
+                                        <i
+                                            class="mr-2 fas fa-coins"></i>{{ Currency::formatForDisplay($user->creditUsage()) }}
                                     </span>
                                 </div>
                             </div>
@@ -206,7 +208,7 @@
                                 </div>
                                 <div class="col-lg-8">
                                     <span style="max-width: 250px;" class="d-inline-block text-truncate">
-                                        {{ $user->referredBy() != Null ? $user->referredBy()->name : "None" }}
+                                        {{ $user->referredBy() != null ? $user->referredBy()->name : 'None' }}
                                     </span>
                                 </div>
                             </div>
@@ -269,24 +271,25 @@
 
                     @foreach ($referrals as $referral)
                         <div class="row mb-3 align-items-center">
-                          <div class="col-md-4 col-sm-12 mb-1 mb-md-0">
-                            <label class="mb-0">User ID: {{ $referral->id ?? 'Deleted' }}</label>
-                          </div>
-                          <div class="col-md-4 col-sm-12 mb-1 mb-md-0">
-                            <span class="d-inline-block text-truncate" style="max-width:250px;">
-                              <i class="mr-2 fas fa-user-check"></i>
-                              @if ($referral->deleted ?? false)
-                                <span class="text-danger">{{ $referral->name }}</span>
-                              @else
-                                <a href="{{ route('admin.users.show', $referral->id) }}">{{ $referral->name }}</a>
-                              @endif
-                            </span>
-                          </div>
-                          <div class="col-md-4 col-sm-12">
-                            <span class="d-inline-block text-truncate" style="max-width:250px;">
-                              <i class="mr-2 fas fa-clock"></i>{{ \Carbon\Carbon::parse($referral->created_at)->diffForHumans() }}
-                            </span>
-                          </div>
+                            <div class="col-md-4 col-sm-12 mb-1 mb-md-0">
+                                <label class="mb-0">User ID: {{ $referral->id ?? 'N/A' }}</label>
+                            </div>
+                            <div class="col-md-4 col-sm-12 mb-1 mb-md-0">
+                                <span class="d-inline-block text-truncate" style="max-width:250px;">
+                                    <i class="mr-2 fas fa-user-check"></i>
+                                    @if ($referral->deleted ?? false)
+                                        <span class="text-danger">{{ $referral->name }}</span>
+                                    @else
+                                        <a
+                                            href="{{ route('admin.users.show', $referral->id) }}">{{ $referral->name }}</a>
+                                    @endif
+                                </span>
+                            </div>
+                            <div class="col-md-4 col-sm-12">
+                                <span class="d-inline-block text-truncate" style="max-width:250px;">
+                                    <i class="mr-2 fas fa-clock"></i>{{ $referral->created_at->diffForHumans() }}
+                                </span>
+                            </div>
                         </div>
                     @endforeach
                 </div>


### PR DESCRIPTION
### This PR makes it easier for admins to track deleted referrals on a account therefore being able to deduce if a user is abusing the referral system.

**Problem Statement:**
Currently, when an account created with a referral code is deleted, the referral record disappears. This makes it hard to audit referral credits and allows users to abuse the referral system by creating and deleting accounts to gain credits fraudulently.

**Solutions given by the issue author:**
1. When deleting an account, preserve the referral history. Specifically, keep the username or a marker under the referring user's info so that deleted accounts are still listed in their referral history (e.g., "deleted user" or similar).
2. Remove credits earned by the referrer when the referred account is deleted. This closes the loophole for referral abuse but may require handling for negative credit balances.

**Reference:**
Fixes [#904](https://github.com/Ctrlpanel-gg/panel/issues/904)

**Implementation Details:**
- Update the user deletion logic to retain referral tracking for deleted accounts.
- However, I have not implemented the removal of credits due to 2 reasons:
    * 1. due to the problem of negative credits
    * 2. due to how controversial the solution is.
---
Feel free to give suggestions