### PR TITLE
⛏️Fix route preparation/serialization issue upon executing route cache command

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -67,9 +67,7 @@ Route::middleware(['auth', 'checkSuspended'])->group(function () {
     Route::patch('/servers/cancel/{server}', [ServerController::class, 'cancel'])->name('servers.cancel');
     Route::post('/servers/validateDeploymentVariables', [ServerController::class, 'validateDeploymentVariables'])->name('servers.validateDeploymentVariables');
     Route::patch('/servers/{server}/billing_priority', [ServerController::class, 'updateBillingPriority'])->name('servers.updateBillingPriority');
-    Route::delete('/servers/{server}', [ServerController::class, 'destroy'])->name('servers.destroy');
-    Route::patch('/servers/{server}', [ServerController::class, 'update'])->name('servers.update');
-    Route::resource('servers', ServerController::class);
+    Route::resource('servers', ServerController::class)->except('update');
 
     try {
         $serverSettings = app(App\Settings\ServerSettings::class);


### PR DESCRIPTION
###  This PR fixes the route preparation issue upon executing `php artisan route:cache`
### Root Cause
- We had a update and destroy server routes defined prior to the ServerController resource routes
- This caused the destroy and the non-existent update routes to conflict with the resource routes
### Fix
- Let ServerController resource routes take priority and exclude update route as there is no update method defined in the controller itself
