### PR TITLE
feat: add server suspension reminder notifications

### DIFF
--- a/app/Console/Commands/NotifyServerSuspension.php
+++ b/app/Console/Commands/NotifyServerSuspension.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Helpers\CurrencyHelper;
+use App\Models\Product;
+use App\Models\Server;
+use App\Models\User;
+use App\Notifications\ServerSuspensionWarningNotification;
+use Carbon\Carbon;
+use Exception;
+use Illuminate\Console\Command;
+
+class NotifyServerSuspension extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'servers:notify-suspension';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Notify users 3 days before their servers are suspended';
+
+    /**
+     * A list of users and their servers that have to be notified
+     * @var array
+     */
+    protected $usersToNotify = [];
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $serversChecked = 0;
+        $serversNotified = 0;
+        $currencyHelper = new CurrencyHelper();
+
+        // Get all servers that are not suspended
+        Server::whereNull('suspended')
+            ->with(['user', 'product'])
+            ->byBillingPriority()
+            ->chunk(10, function ($servers) use (&$serversChecked, &$serversNotified, $currencyHelper) {
+                /** @var Server $server */
+                foreach ($servers as $server) {
+                    $serversChecked++;
+
+                    /** @var Product $product */
+                    $product = $server->product;
+                    /** @var User $user */
+                    $user = $server->user;
+
+                    if (!$product || !$user) {
+                        continue;
+                    }
+
+                    $billing_period = $product->billing_period;
+                    $suspensionDate = null;
+                    switch ($billing_period) {
+                        case 'annually':
+                            $suspensionDate = Carbon::parse($server->last_billed)->addYear();
+                            break;
+                        case 'half-annually':
+                            $suspensionDate = Carbon::parse($server->last_billed)->addMonths(6);
+                            break;
+                        case 'quarterly':
+                            $suspensionDate = Carbon::parse($server->last_billed)->addMonths(3);
+                            break;
+                        case 'monthly':
+                            $suspensionDate = Carbon::parse($server->last_billed)->addMonth();
+                            break;
+                        case 'weekly':
+                            $suspensionDate = Carbon::parse($server->last_billed)->addWeek();
+                            break;
+                        case 'daily':
+                            $suspensionDate = Carbon::parse($server->last_billed)->addDay();
+                            break;
+                        case 'hourly':
+                            $suspensionDate = Carbon::parse($server->last_billed)->addHour();
+                        default:
+                            $suspensionDate = Carbon::parse($server->last_billed)->addHour();
+                            break;
+                    }
+                    $userCredits = $currencyHelper->convertForDisplay($user->credits);
+                    $serverPrice = $currencyHelper->convertForDisplay($product->price);
+
+                    $isCanceled = $server->canceled;
+                    $hasInsufficientCredits = $userCredits < $serverPrice && $serverPrice != 0;
+
+                    if (!($isCanceled || $hasInsufficientCredits)) {
+                        continue;
+                    }
+
+                    $now = Carbon::now();
+                    $daysUntilSuspension = $now->diffInDays($suspensionDate, false);
+
+                    if ($daysUntilSuspension >= 0 && $daysUntilSuspension <= 3) {
+                        $this->line("<fg=yellow>{$server->name}</> from user: <fg=blue>{$user->name}</> will be suspended in <fg=cyan>{$daysUntilSuspension}</> days. Sending warning...");
+
+                        $server->update(['suspension_warning_sent_at' => now()]);
+                        $serversNotified++;
+
+                        if (!isset($this->usersToNotify[$user->id])) {
+                            $this->usersToNotify[$user->id] = [
+                                'user' => $user,
+                                'servers' => collect()
+                            ];
+                        }
+                        $this->usersToNotify[$user->id]['servers']->push([
+                            'server' => $server,
+                            'suspension_date' => $suspensionDate
+                        ]);
+                    }
+                }
+
+                return $this->notifyUsers();
+            });
+
+        $this->info("Completed! Checked: {$serversChecked} servers, Notified: {$serversNotified} servers");
+
+        return 0;
+    }
+
+    /**
+     * @return bool
+     */
+    public function notifyUsers()
+    {
+        if (!empty($this->usersToNotify)) {
+            foreach ($this->usersToNotify as $userData) {
+                $user = $userData['user'];
+                $servers = $userData['servers'];
+
+                if ($servers->isNotEmpty()) {
+                    $this->line("<fg=yellow>Notified user:</> <fg=blue>{$user->name}</>");
+
+                       $sortedServers = $servers->sortBy(function ($serverData) {
+                        return $serverData['suspension_date']->timestamp;
+                    });
+
+                    $user->notify(new ServerSuspensionWarningNotification($sortedServers));
+                }
+            }
+        }
+
+        // Reset array
+        $this->usersToNotify = [];
+        return true;
+    }
+}

--- a/app/Console/Commands/NotifyServerSuspension.php
+++ b/app/Console/Commands/NotifyServerSuspension.php
@@ -210,9 +210,7 @@ class NotifyServerSuspension extends Command
      */
     private function hasInsufficientCredits($user, $product)
     {
-        $userCredits = $this->currencyHelper->formatForCommands($user->credits);
-        $serverPrice = $this->currencyHelper->formatForCommands($product->price);
-
-        return $userCredits < $serverPrice && $serverPrice != 0;
+        // Direct integer comparison; both values are in thousandths
+        return $user->credits < $product->price && $product->price != 0;
     }
 }

--- a/app/Console/Commands/NotifyServerSuspension.php
+++ b/app/Console/Commands/NotifyServerSuspension.php
@@ -136,7 +136,7 @@ class NotifyServerSuspension extends Command
 
         $this->notifyUsers();
 
-        $this->info("Completed! Checked: {$serversChecked} servers, Notified: {$serversNotified} servers");
+        $this->info("Completed! Checked: {$serversChecked} servers, Sent warnings for: {$serversNotified} servers");
 
         return 0;
     }

--- a/app/Console/Commands/NotifyServerSuspension.php
+++ b/app/Console/Commands/NotifyServerSuspension.php
@@ -99,8 +99,8 @@ class NotifyServerSuspension extends Command
                             $suspensionDate = Carbon::parse($server->last_billed)->addHour();
                             break;
                     }
-                    $userCredits = ($user->credits)/1000;
-                    $serverPrice = ($product->price)/1000;
+                    $userCredits = $currencyHelper->formatForCommands($user->credits);
+                    $serverPrice = $currencyHelper->formatForCommands($product->price);
 
                     $isCanceled = $server->canceled;
                     $hasInsufficientCredits = $userCredits < $serverPrice && $serverPrice != 0;

--- a/app/Console/Commands/NotifyServerSuspension.php
+++ b/app/Console/Commands/NotifyServerSuspension.php
@@ -99,8 +99,8 @@ class NotifyServerSuspension extends Command
                             $suspensionDate = Carbon::parse($server->last_billed)->addHour();
                             break;
                     }
-                    $userCredits = $currencyHelper->convertForDisplay($user->credits);
-                    $serverPrice = $currencyHelper->convertForDisplay($product->price);
+                    $userCredits = ($user->credits)/1000;
+                    $serverPrice = ($product->price)/1000;
 
                     $isCanceled = $server->canceled;
                     $hasInsufficientCredits = $userCredits < $serverPrice && $serverPrice != 0;

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,6 +16,7 @@ class Kernel extends ConsoleKernel
     protected $commands = [
         Commands\ChargeServers::class,
         Commands\DeleteExpiredCoupons::class,
+        Commands\NotifyServerSuspension::class,
     ];
 
     /**
@@ -27,6 +28,7 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         $schedule->command('servers:charge')->everyMinute();
+        $schedule->command('servers:notify-suspension')->daily();
         $schedule->command('cp:versioncheck:get')->daily();
         $schedule->command('payments:open:clear')->daily();
         $schedule->command('coupons:delete')->daily();

--- a/app/Helpers/CurrencyHelper.php
+++ b/app/Helpers/CurrencyHelper.php
@@ -6,7 +6,7 @@ use NumberFormatter;
 
 class CurrencyHelper
 {
-    public function convertForDisplay($amount)
+    private function convertForDisplay($amount)
     {
         return $amount / 1000;
     }

--- a/app/Helpers/CurrencyHelper.php
+++ b/app/Helpers/CurrencyHelper.php
@@ -43,7 +43,8 @@ class CurrencyHelper
      * @param int $amount Amount in the smallest currency unit (e.g., thousandths).
      * @return float Converted amount for commands.
      */
-    public function formatForCommands($amount) {
+    public function formatForCommands($amount)
+    {
         return $this->convertForDisplay($amount);
     }
 }

--- a/app/Helpers/CurrencyHelper.php
+++ b/app/Helpers/CurrencyHelper.php
@@ -35,7 +35,15 @@ class CurrencyHelper
         return $formatter->formatCurrency($this->convertForDisplay($amount), $currency_code);
     }
 
-    public function formatForCommands($amount){
+    /**
+     * Formats the given amount for use in commands.
+     *
+     * Converts the amount from the smallest currency unit to a float.
+     *
+     * @param int $amount Amount in the smallest currency unit (e.g., thousandths).
+     * @return float Converted amount for commands.
+     */
+    public function formatForCommands($amount) {
         return $this->convertForDisplay($amount);
     }
 }

--- a/app/Helpers/CurrencyHelper.php
+++ b/app/Helpers/CurrencyHelper.php
@@ -6,7 +6,7 @@ use NumberFormatter;
 
 class CurrencyHelper
 {
-    private function convertForDisplay($amount)
+    public function convertForDisplay($amount)
     {
         return $amount / 1000;
     }

--- a/app/Helpers/CurrencyHelper.php
+++ b/app/Helpers/CurrencyHelper.php
@@ -34,4 +34,8 @@ class CurrencyHelper
 
         return $formatter->formatCurrency($this->convertForDisplay($amount), $currency_code);
     }
+
+    public function formatForCommands($amount){
+        return $this->convertForDisplay($amount);
+    }
 }

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -61,7 +61,8 @@ class Server extends Model
         "product_id",
         "pterodactyl_id",
         "last_billed",
-        "canceled"
+        "canceled",
+        "suspension_warning_sent_at"
     ];
 
     /**
@@ -144,6 +145,7 @@ class Server extends Model
             $this->update([
                 'suspended' => null,
                 'last_billed' => Carbon::now()->toDateTimeString(),
+                'suspension_warning_sent_at' => null,
             ]);
         }
 

--- a/app/Notifications/ServerSuspensionWarningNotification.php
+++ b/app/Notifications/ServerSuspensionWarningNotification.php
@@ -6,7 +6,6 @@ use App\Helpers\CurrencyHelper;
 use App\Settings\MailSettings;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
-
 class ServerSuspensionWarningNotification extends Notification
 {
     protected $servers;
@@ -19,33 +18,6 @@ class ServerSuspensionWarningNotification extends Notification
     public function __construct($servers)
     {
         $this->servers = $servers;
-    }
-
-    /**
-     * Format time remaining until suspension (similar to HomeController)
-     */
-    protected function formatTimeLeft($date)
-    {
-        if (!$date) return 'Unknown';
-
-        $now = now();
-        $daysLeft = $now->diffInDays($date, false);
-        $hoursLeft = $now->diffInHours($date, false);
-        $minutesLeft = $now->diffInMinutes($date, false);
-
-        if ($daysLeft > 0) {
-            return floor($daysLeft) . ' ' . (floor($daysLeft) == 1 ? 'day' : 'days');
-        }
-
-        if ($hoursLeft > 0) {
-            return floor($hoursLeft) . ' ' . (floor($hoursLeft) == 1 ? 'hour' : 'hours');
-        }
-
-        if ($minutesLeft > 0) {
-            return floor($minutesLeft) . ' ' . (floor($minutesLeft) == 1 ? 'minute' : 'minutes');
-        }
-
-        return 'Less than 1 minute';
     }
 
     /**

--- a/app/Notifications/ServerSuspensionWarningNotification.php
+++ b/app/Notifications/ServerSuspensionWarningNotification.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Settings\MailSettings;
+use App\Settings\PterodactylSettings;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class ServerSuspensionWarningNotification extends Notification
+{
+
+    protected $pterodactylSettings;
+    protected $servers;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct($servers)
+    {
+        $this->pterodactylSettings = app(PterodactylSettings::class);
+        $this->servers = $servers;
+    }
+
+    /**
+     * Format time remaining until suspension (similar to HomeController)
+     */
+    protected function formatTimeLeft($date)
+    {
+        if (!$date) return 'Unknown';
+
+        $now = now();
+        $daysLeft = $now->diffInDays($date, false);
+        $hoursLeft = $now->diffInHours($date, false);
+        $minutesLeft = $now->diffInMinutes($date, false);
+
+        if ($daysLeft > 1) {
+            return floor($daysLeft) . ' days';
+        }
+
+        if ($hoursLeft > 1) {
+            return floor($hoursLeft) . ' hours';
+        }
+
+        if ($minutesLeft > 1) {
+            return floor($minutesLeft) . ' minutes';
+        }
+
+        return 'Less than 1 minute';
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        $channels = ['database'];
+
+        $mailSettings = app(\App\Settings\MailSettings::class);
+
+        if ($mailSettings->mail_from_address && $mailSettings->mail_host) {
+            $channels[] = 'mail';
+        }
+
+        return $channels;
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        $sortedServers = $this->servers->sortBy(function ($serverData) {
+            return $serverData['suspension_date']->timestamp;
+        });
+
+        $serverList = $sortedServers->map(function ($serverData, $index) {
+            $server = $serverData['server'];
+            $timeLeft = $this->formatTimeLeft($serverData['suspension_date']);
+            $priorityIndicator = $index === 0 ? ' (Will be suspended first)' : '';
+            return $server->name . ' (in ' . $timeLeft . ')' . $priorityIndicator;
+        })->implode(', ');
+
+        return (new MailMessage)
+                    ->subject('Warning: Your servers will be suspended soon')
+                    ->line('Your following server(s) will be suspended if you do not add sufficient credits to your account:')
+                    ->line($serverList)
+                    ->line('⚠️  **Important:** Servers will be suspended in the order shown above. If you don\'t add credits before the first server is billed, subsequent servers will also be suspended.')
+                    ->line('To prevent suspension, please purchase more credits immediately.')
+                    ->line('If you have any questions please let us know.')
+                    ->action('Add Credits', route('home'));
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        // Sort servers by suspension time (earliest first)
+        $sortedServers = $this->servers->sortBy(function ($serverData) {
+            return $serverData['suspension_date']->timestamp;
+        });
+
+        $serverList = $sortedServers->map(function ($serverData, $index) {
+            $server = $serverData['server'];
+            $timeLeft = $this->formatTimeLeft($serverData['suspension_date']);
+            $priorityIndicator = $index === 0 ? ' <strong>(Will be suspended first)</strong>' : '';
+            return '<li>' . $server->name . ' (in ' . $timeLeft . ')' . $priorityIndicator . '</li>';
+        })->implode('');
+
+        return [
+            'title' => 'Warning: Your servers will be suspended soon',
+            'content' => '
+                <h5>Warning: Your servers will be suspended soon</h5>
+                <p>Your following server(s) will be suspended if you do not add sufficient credits to your account:</p>
+                <ul>' . $serverList . '</ul>
+                <p><strong>⚠️ Important:</strong> Servers will be suspended in the order shown above. If you don\'t add credits before the first server is billed, subsequent servers will also be suspended.</p>
+                <p>To prevent suspension, please purchase more credits immediately.</p>
+                <p>If you have any questions please let us know.</p>
+                <p>Regards,<br />'.config('app.name', 'Laravel').'</p>
+            ',
+        ];
+    }
+}

--- a/app/Notifications/ServerSuspensionWarningNotification.php
+++ b/app/Notifications/ServerSuspensionWarningNotification.php
@@ -54,8 +54,8 @@ class ServerSuspensionWarningNotification extends Notification
         });
         $serverList = $sortedServers->map(function ($serverData, $index) {
             $server = $serverData['server'];
-            return $server->name . ' (will be suspended on ' . $serverData['suspension_date']->format('M j, Y \a\t g:i A') . ')';
-        })->implode(', ');
+            return '• ' . $server->name . ' (will be suspended on ' . $serverData['suspension_date']->format('M j, Y \a\t g:i A') . ')';
+        })->implode("\n");
 
         $currentCredits = app(CurrencyHelper::class)->formatForDisplay($notifiable->credits);
         $totalNeededDisplay = app(CurrencyHelper::class)->formatForDisplay($totalCreditsNeeded);

--- a/database/migrations/2025_11_01_144100_add_suspension_warning_sent_at_to_servers_table.php
+++ b/database/migrations/2025_11_01_144100_add_suspension_warning_sent_at_to_servers_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddSuspensionWarningSentAtToServersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            $table->datetime('suspension_warning_sent_at')->nullable()->after('suspended');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            $table->dropColumn('suspension_warning_sent_at');
+        });
+    }
+}


### PR DESCRIPTION
### This PR adds an automated system that warns users three days before their servers are suspended due to low credits or cancellation. It includes a new console command to detect at-risk servers, a notification class to alert users via email and database, a tracking field in the servers table, and schedules the command to run daily.
<img width="1366" height="724" alt="image" src="https://github.com/user-attachments/assets/063abdfd-00b6-4ada-b12a-815281b31d6b" />
<img width="787" height="342" alt="image" src="https://github.com/user-attachments/assets/a4e2ae72-0b6c-44bb-8525-a9a8bc8ea071" />
