### PR TITLE
Change product change list from "created at" to price

### DIFF
--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -407,7 +407,7 @@ class ServerController extends Controller
 
         //$currentProductEggs = $currentProduct->eggs->pluck('id')->toArray();
 
-        return Product::orderBy('created_at')
+        return Product::orderBy('price', 'asc')
             ->with('nodes')->with('eggs')
             ->whereHas('nodes', function (Builder $builder) use ($nodeId) {
                 $builder->where('id', $nodeId);


### PR DESCRIPTION
This pull request makes a targeted change to the `getUpgradeOptions` function in `ServerController.php` to improve the way upgrade options are sorted. Instead of ordering products by their creation date, the products are now ordered by price in ascending order, which should provide users with a more logical and user-friendly upgrade path.

- Changed product sorting in `getUpgradeOptions` to order by `price` (ascending) instead of `created_at` for more relevant upgrade option display.
