### PR TITLE
Sort products by price and fix password autocomplete

### DIFF
--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -407,7 +407,7 @@ class ServerController extends Controller
 
         //$currentProductEggs = $currentProduct->eggs->pluck('id')->toArray();
 
-        return Product::orderBy('created_at')
+        return Product::orderBy('price', 'asc')
             ->with('nodes')->with('eggs')
             ->whereHas('nodes', function (Builder $builder) use ($nodeId) {
                 $builder->where('id', $nodeId);

--- a/themes/default/views/admin/users/edit.blade.php
+++ b/themes/default/views/admin/users/edit.blade.php
@@ -137,7 +137,7 @@
                         <div class="card-body">
                             <div class="col">
                                 <div class="form-group"><label>{{__('New Password')}}</label> <input
-                                        class="form-control @error('new_password') is-invalid @enderror"
+                                        autocomplete="new-password" class="form-control @error('new_password') is-invalid @enderror"
                                         name="new_password" id="new_password" type="password" placeholder="••••••">
 
                                     @error('new_password')


### PR DESCRIPTION
This pull request makes adjustments to improve user experience and functionality:

* Product Sorting Change: Minor adjustment to the sorting of products when retrieving upgrade options in the ServerController. Products are now ordered by ascending price instead of creation date, which should improve the relevance of upgrade suggestions for users.
- Changed product sorting in getUpgradeOptions from created_at to ascending price to prioritize cheaper upgrade options. (app/Http/Controllers/ServerController.php)

* Password Field Autocomplete Fix: Added autocomplete="new-password" attribute to the "New Password" field in the admin user edit form to prevent browsers from auto-filling the field with the user's login password, enhancing security and usability.
- Prevents unintended password auto-substitution when admins edit user profiles. (themes/default/views/admin/users/edit.blade.php)

These changes are backward-compatible and do not affect existing functionality.