### PR TITLE
Made it possible to select an entire category of eggs in the product settings

### DIFF
--- a/themes/default/views/admin/products/create.blade.php
+++ b/themes/default/views/admin/products/create.blade.php
@@ -1,425 +1,476 @@
 @extends('layouts.main')
 
 @section('content')
-  <!-- CONTENT HEADER -->
-  <section class="content-header">
-    <div class="container-fluid">
-      <div class="mb-2 row">
-        <div class="col-sm-6">
-          <h1>{{ __('Products') }}</h1>
-        </div>
-        <div class="col-sm-6">
-          <ol class="breadcrumb float-sm-right">
-            <li class="breadcrumb-item"><a href="{{ route('home') }}">{{ __('Dashboard') }}</a></li>
-            <li class="breadcrumb-item"><a href="{{ route('admin.products.index') }}">{{ __('Products') }}</a>
-            </li>
-            <li class="breadcrumb-item"><a class="text-muted"
-                href="{{ route('admin.products.create') }}">{{ __('Create') }}</a>
-            </li>
-          </ol>
-        </div>
-      </div>
-    </div>
-  </section>
-  <!-- END CONTENT HEADER -->
-
-  <!-- MAIN CONTENT -->
-  <section class="content">
-    <div class="container-fluid">
-      <form action="{{ route('admin.products.store') }}" method="POST">
-        @csrf
-        <div class="row">
-          <div class="col-lg-6">
-            <div class="card">
-              <div class="card-header">
-                <h5 class="card-title">{{ __('Product Details') }}</h5>
-              </div>
-              <div class="card-body">
-
-                <div class="flex-row-reverse d-flex">
-                  <div class="custom-control custom-switch">
-                    <input type="checkbox" name="disabled" class="custom-control-input custom-control-input-danger"
-                      id="switch1">
-                    <label class="custom-control-label" for="switch1">{{ __('Disabled') }} <i data-toggle="popover"
-                        data-trigger="hover" data-content="{{ __('Will hide this option from being selected') }}"
-                        class="fas fa-info-circle"></i></label>
-                  </div>
+    <!-- CONTENT HEADER -->
+    <section class="content-header">
+        <div class="container-fluid">
+            <div class="mb-2 row">
+                <div class="col-sm-6">
+                    <h1>{{ __('Products') }}</h1>
                 </div>
-
-                <div class="row">
-                  <div class="col-lg-12">
-                    <div class="form-group">
-                      <label for="name">{{ __('Name') }}</label>
-                      <input value="{{ $product->name ?? old('name') }}" id="name" name="name" type="text"
-                        class="form-control @error('name') is-invalid @enderror" required="required">
-                      @error('name')
-                        <div class="invalid-feedback">
-                          {{ $message }}
-                        </div>
-                      @enderror
-                    </div>
-                  </div>
-                  <div class="col-lg-12">
-                    <div class="form-group">
-                      <label for="description">{{ __('Description') }} <i data-toggle="popover" data-trigger="hover"
-                          data-content="{{ __('This is what the users sees') }}" class="fas fa-info-circle"></i></label>
-                      <textarea id="description" name="description" type="text"
-                        class="form-control @error('description') is-invalid @enderror"
-                        required="required">{{ $product->description ?? old('description') }}</textarea>
-                      @error('description')
-                        <div class="invalid-feedback">
-                          {{ $message }}
-                        </div>
-                      @enderror
-                    </div>
-                  </div>
+                <div class="col-sm-6">
+                    <ol class="breadcrumb float-sm-right">
+                        <li class="breadcrumb-item"><a href="{{ route('home') }}">{{ __('Dashboard') }}</a></li>
+                        <li class="breadcrumb-item"><a href="{{ route('admin.products.index') }}">{{ __('Products') }}</a>
+                        </li>
+                        <li class="breadcrumb-item"><a class="text-muted"
+                                href="{{ route('admin.products.create') }}">{{ __('Create') }}</a>
+                        </li>
+                    </ol>
                 </div>
-                <div class="row">
-                  <div class="col-lg-6">
-                    <div class="form-group">
-                      <label for="billing_period">{{ __('Billing Period') }} <i data-toggle="popover" data-trigger="hover"
-                          data-content="{{ __('Period when the user will be charged for the given price') }}"
-                          class="fas fa-info-circle"></i></label>
-                      <select id="billing_period" style="width:100%" class="custom-select" name="billing_period" required
-                        autocomplete="off" @error('billing_period') is-invalid @enderror>
-                        <option value="hourly" @selected(old('billing_period', $product->billing_period ?? '') == 'hourly')>
-                          {{ __('Hourly') }}
-                        </option>
-                        <option value="daily" @selected(old('billing_period', $product->billing_period ?? '') == 'daily')>
-                          {{ __('Daily') }}
-                        </option>
-                        <option value="weekly" @selected(old('billing_period', $product->billing_period ?? '') == 'weekly')>
-                          {{ __('Weekly') }}
-                        </option>
-                        <option value="monthly" @selected(old('billing_period', $product->billing_period ?? '') == 'monthly')>
-                          {{ __('Monthly') }}
-                        </option>
-                        <option value="quarterly" @selected(old('billing_period', $product->billing_period ?? '') == 'quarterly')>
-                          {{ __('Quarterly') }}
-                        </option>
-                        <option value="half-annually" @selected(old('billing_period', $product->billing_period ?? '') == 'half-annually')>
-                          {{ __('Half Annually') }}
-                        </option>
-                        <option value="annually" @selected(old('billing_period', $product->billing_period ?? '') == 'annually')>
-                          {{ __('Annually') }}
-                        </option>
-                      </select>
-                      @error('billing_period')
-                        <div class="invalid-feedback">
-                          {{ $message }}
-                        </div>
-                      @enderror
-                    </div>
-                  </div>
-                  <div class="col-lg-6">
-                    <div class="form-group">
-                      <label for="default_billing_priority">
-                        {{ __('Default Billing Priority') }}
-                        <i data-toggle="popover" data-trigger="hover"
-                          data-content="{{ __('Defines the priority at which the servers in this product will be charged.') }}"
-                          class="fas fa-info-circle"></i>
-                      </label>
-                      <select id="default_billing_priority" style="width:100%" class="custom-select"
-                        name="default_billing_priority" required autocomplete="off" @error('default_billing_priority')
-                        is-invalid @enderror>
-                        @foreach(App\Enums\BillingPriority::options() as $value => $label)
-                          <option value="{{ $value }}" @selected(old('default_billing_priority', $product->default_billing_priority->value ?? '') == $value || $value == App\Enums\BillingPriority::MEDIUM->value)>
-                            {{ $label }}
-                          </option>
-                        @endforeach
-                      </select>
-                      @error('default_billing_priority')
-                        <div class="invalid-feedback">
-                          {{ $message }}
-                        </div>
-                      @enderror
-                    </div>
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col-lg-6">
-                    <div class="form-group">
-                      <label for="price">{{ __('Price in') }} {{ $credits_display_name }}</label>
-                      <input value="{{ old('price', isset($product) ? Currency::formatForForm($product->price) : '') }}"
-                        id="price" name="price" step=".0001" type="number"
-                        class="form-control @error('price') is-invalid @enderror" required="required">
-                      @error('price')
-                        <div class="invalid-feedback">
-                          {{ $message }}
-                        </div>
-                      @enderror
-                    </div>
-                  </div>
-                  <div class="col-lg-6">
-                    <div class="form-group">
-                      <label for="minimum_credits">{{ __('Minimum') }} {{ $credits_display_name }}
-                        <i data-toggle="popover" data-trigger="hover"
-                          data-content="{{ __('Setting to empty will use the value from configuration.') }}"
-                          class="fas fa-info-circle"></i></label>
-                      <input
-                        value="{{ old('minimum_credits', (isset($product) && $product->minimum_credits) ? Currency::formatForForm($product->minimum_credits) : null) }}"
-                        id="minimum_credits" name="minimum_credits" type="number"
-                        class="form-control @error('minimum_credits') is-invalid @enderror">
-                      @error('minimum_credits')
-                        <div class="invalid-feedback">
-                          {{ $message }}
-                        </div>
-                      @enderror
-                    </div>
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col-lg-6">
-                    <div class="form-group">
-                      <label for="cpu">{{ __('Cpu') }}</label>
-                      <input value="{{ $product->cpu ?? old('cpu') }}" id="cpu" name="cpu" type="number" min="0"
-                        class="form-control @error('cpu') is-invalid @enderror" required="required">
-                      <div class="text-muted small">{{ __('Set to 0 for Unlimited') }}</div>
-                      @error('cpu')
-                        <div class="invalid-feedback">
-                          {{ $message }}
-                        </div>
-                      @enderror
-                    </div>
-                  </div>
-                  <div class="col-lg-6">
-                    <div class="form-group">
-                      <label for="disk">{{ __('Disk') }}</label>
-                      <input value="{{ $product->disk ?? (old('disk') ?? 1000) }}" id="disk" name="disk" type="number"
-                        min="0" class="form-control @error('disk') is-invalid @enderror" required="required">
-                      <div class="text-muted small">{{ __('Set to 0 for Unlimited') }}</div>
-                      @error('disk')
-                        <div class="invalid-feedback">
-                          {{ $message }}
-                        </div>
-                      @enderror
-                    </div>
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col-lg-6">
-                    <div class="form-group">
-                      <label for="memory">{{ __('Memory') }}</label>
-                      <input value="{{ $product->memory ?? old('memory') }}" id="memory" name="memory" type="number"
-                        min="0" class="form-control @error('memory') is-invalid @enderror" required="required">
-                      <div class="text-muted small">{{ __('Set to 0 for Unlimited') }}</div>
-                      @error('memory')
-                        <div class="invalid-feedback">
-                          {{ $message }}
-                        </div>
-                      @enderror
-                    </div>
-                  </div>
-                  <div class="col-lg-6">
-                    <div class="form-group">
-                      <label for="io">{{ __('IO') }}</label>
-                      <input value="{{ $product->io ?? (old('io') ?? 500) }}" id="io" name="io" type="number"
-                        class="form-control @error('io') is-invalid @enderror" required="required">
-                      @error('io')
-                        <div class="invalid-feedback">
-                          {{ $message }}
-                        </div>
-                      @enderror
-                    </div>
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col-lg-6">
-                    <div class="form-group">
-                      <label for="swap">{{ __('Swap') }}</label>
-                      <input value="{{ $product->swap ?? old('swap') }}" id="swap" name="swap" type="number" min="-1"
-                        class="form-control @error('swap') is-invalid @enderror" required="required">
-                      <div class="text-muted small">
-                        {{ __('Set to -1 for Unlimited, 0 for Disabled, or any positive number.') }}
-                      </div>
-                      @error('swap')
-                        <div class="invalid-feedback">
-                          {{ $message }}
-                        </div>
-                      @enderror
-                    </div>
-                  </div>
-                  <div class="col-lg-6">
-                    <div class="form-group">
-                      <label for="serverlimit">{{ __('Serverlimit') }}</label>
-                      <i data-toggle="popover" data-trigger="hover"
-                        data-content="{{ __('The maximum amount of Servers that can be created with this Product per User') }}"
-                        class="fas fa-info-circle">
-                      </i>
-                      <input value="{{ $product->serverlimit ?? (old('serverlimit') ?? 0) }}" id="serverlimit"
-                        name="serverlimit" type="number" class="form-control @error('serverlimit') is-invalid @enderror"
-                        required="required">
-                      @error('serverlimit')
-                        <div class="invalid-feedback">
-                          {{ $message }}
-                        </div>
-                      @enderror
-                    </div>
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col-lg-4">
-                    <div class="form-group">
-                      <label for="allocations">{{ __('Allocations') }}</label>
-                      <input value="{{ $product->allocations ?? (old('allocations') ?? 0) }}" id="allocations"
-                        name="allocations" type="number" class="form-control @error('allocations') is-invalid @enderror"
-                        required="required">
-                      @error('allocations')
-                        <div class="invalid-feedback">
-                          {{ $message }}
-                        </div>
-                      @enderror
-                    </div>
-                  </div>
-                  <div class="col-lg-4">
-                    <div class="form-group">
-                      <label for="databases">{{ __('Databases') }}</label>
-                      <input value="{{ $product->databases ?? (old('databases') ?? 1) }}" id="databases" name="databases"
-                        type="number" class="form-control @error('databases') is-invalid @enderror" required="required">
-                      @error('databases')
-                        <div class="invalid-feedback">
-                          {{ $message }}
-                        </div>
-                      @enderror
-                    </div>
-                  </div>
-                  <div class="col-lg-4">
-                    <div class="form-group">
-                      <label for="backups">{{ __('Backups') }}</label>
-                      <input value="{{ $product->backups ?? (old('backups') ?? 1) }}" id="backups" name="backups"
-                        type="number" class="form-control @error('backups') is-invalid @enderror" required="required">
-                      @error('backups')
-                        <div class="invalid-feedback">
-                          {{ $message }}
-                        </div>
-                      @enderror
-                    </div>
-                  </div>
-                </div>
-
-                <div class="row">
-                  <div class="col-lg-6">
-                    <div class="form-group">
-                      <input type="checkbox" value="1" id="oom_killer" name="oom_killer">
-                      <label for="oom_killer">
-                        {{ __('OOM Killer') }}
-                        <i data-toggle="popover" data-trigger="hover"
-                          data-content="{{ __('Enable or Disable the OOM Killer for this Product.') }}"
-                          class="fas fa-info-circle">
-                        </i>
-                      </label>
-                    </div>
-                  </div>
-                </div>
-
-                <div class="text-right form-group">
-                  <button type="submit" class="btn btn-primary">
-                    {{ __('Submit') }}
-                  </button>
-                </div>
-
-              </div>
             </div>
-          </div>
+        </div>
+    </section>
+    <!-- END CONTENT HEADER -->
 
-          <div class="col-lg-6">
-            <div class="card">
-              <div class="card-header">
-                <h5 class="card-title">{{ __('Product Linking') }}
-                  <i data-toggle="popover" data-trigger="hover"
-                    data-content="{{ __('Link your products to nodes and eggs to create dynamic pricing for each option') }}"
-                    class="fas fa-info-circle"></i>
-                </h5>
-              </div>
-              <div class="card-body">
+    <!-- MAIN CONTENT -->
+    <section class="content">
+        <div class="container-fluid">
+            <form action="{{ route('admin.products.store') }}" method="POST">
+                @csrf
+                <div class="row">
+                    <div class="col-lg-6">
+                        <div class="card">
+                            <div class="card-header">
+                                <h5 class="card-title">{{ __('Product Details') }}</h5>
+                            </div>
+                            <div class="card-body">
 
-                <div class="form-group">
-                  <label for="nodes">{{ __('Nodes') }}</label>
-                  <select id="nodes" style="width:100%" class="custom-select @error('nodes') is-invalid @enderror"
-                    name="nodes[]" multiple="multiple" autocomplete="off">
-                    @foreach ($locations as $location)
-                      <optgroup label="{{ $location->name }}">
-                        @foreach ($location->nodes as $node)
-                          <option @if (isset($product)) @if ($product->nodes->contains('id', $node->id)) selected @endif
-                          @endif value="{{ $node->id }}">{{ $node->name }}</option>
-                        @endforeach
-                      </optgroup>
-                    @endforeach
-                  </select>
-                  @error('nodes')
-                    <div class="text-danger">
-                      {{ $message }}
+                                <div class="flex-row-reverse d-flex">
+                                    <div class="custom-control custom-switch">
+                                        <input type="checkbox" name="disabled"
+                                            class="custom-control-input custom-control-input-danger" id="switch1">
+                                        <label class="custom-control-label" for="switch1">{{ __('Disabled') }} <i
+                                                data-toggle="popover" data-trigger="hover"
+                                                data-content="{{ __('Will hide this option from being selected') }}"
+                                                class="fas fa-info-circle"></i></label>
+                                    </div>
+                                </div>
+
+                                <div class="row">
+                                    <div class="col-lg-12">
+                                        <div class="form-group">
+                                            <label for="name">{{ __('Name') }}</label>
+                                            <input value="{{ $product->name ??  old('name') }}" id="name"
+                                                name="name" type="text"
+                                                class="form-control @error('name') is-invalid @enderror"
+                                                required="required">
+                                            @error('name')
+                                                <div class="invalid-feedback">
+                                                    {{ $message }}
+                                                </div>
+                                            @enderror
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-12">
+                                        <div class="form-group">
+                                            <label for="description">{{ __('Description') }} <i data-toggle="popover"
+                                                    data-trigger="hover"
+                                                    data-content="{{ __('This is what the users sees') }}"
+                                                    class="fas fa-info-circle"></i></label>
+                                            <textarea id="description" name="description" type="text"
+                                                class="form-control @error('description') is-invalid @enderror" required="required">{{ $product->description ?? old('description') }}</textarea>
+                                            @error('description')
+                                                <div class="invalid-feedback">
+                                                    {{ $message }}
+                                                </div>
+                                            @enderror
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="billing_period">{{ __('Billing Period') }} <i
+                                                    data-toggle="popover" data-trigger="hover"
+                                                    data-content="{{ __('Period when the user will be charged for the given price') }}"
+                                                    class="fas fa-info-circle"></i></label>
+                                            <select id="billing_period" style="width: 100%" class="custom-select"
+                                                name="billing_period" required autocomplete="off"
+                                                @error('billing_period') is-invalid @enderror>
+                                                <option value="hourly" @selected(old('billing_period', $product->billing_period ??  '') == 'hourly')>
+                                                    {{ __('Hourly') }}
+                                                </option>
+                                                <option value="daily" @selected(old('billing_period', $product->billing_period ?? '') == 'daily')>
+                                                    {{ __('Daily') }}
+                                                </option>
+                                                <option value="weekly" @selected(old('billing_period', $product->billing_period ??  '') == 'weekly')>
+                                                    {{ __('Weekly') }}
+                                                </option>
+                                                <option value="monthly" @selected(old('billing_period', $product->billing_period ?? '') == 'monthly')>
+                                                    {{ __('Monthly') }}
+                                                </option>
+                                                <option value="quarterly" @selected(old('billing_period', $product->billing_period ?? '') == 'quarterly')>
+                                                    {{ __('Quarterly') }}
+                                                </option>
+                                                <option value="half-annually" @selected(old('billing_period', $product->billing_period ?? '') == 'half-annually')>
+                                                    {{ __('Half Annually') }}
+                                                </option>
+                                                <option value="annually" @selected(old('billing_period', $product->billing_period ?? '') == 'annually')>
+                                                    {{ __('Annually') }}
+                                                </option>
+                                            </select>
+                                            @error('billing_period')
+                                                <div class="invalid-feedback">
+                                                    {{ $message }}
+                                                </div>
+                                            @enderror
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="default_billing_priority">
+                                                {{ __('Default Billing Priority') }}
+                                                <i
+                                                    data-toggle="popover"
+                                                    data-trigger="hover"
+                                                    data-content="{{ __('Defines the priority at which the servers in this product will be charged. ') }}"
+                                                    class="fas fa-info-circle"></i>
+                                            </label>
+                                            <select
+                                                id="default_billing_priority"
+                                                style="width:100%"
+                                                class="custom-select"
+                                                name="default_billing_priority" required autocomplete="off"
+                                                @error('default_billing_priority') is-invalid @enderror
+                                            >
+                                                @foreach(App\Enums\BillingPriority::options() as $value => $label)
+                                                    <option value="{{ $value }}" @selected(old('default_billing_priority', $product->default_billing_priority->value ?? '') == $value || $value == App\Enums\BillingPriority::MEDIUM->value)>
+                                                        {{ $label }}
+                                                    </option>
+                                                @endforeach
+                                            </select>
+                                            @error('default_billing_priority')
+                                                <div class="invalid-feedback">
+                                                    {{ $message }}
+                                                </div>
+                                            @enderror
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="price">{{ __('Price in') }} {{ $credits_display_name }}</label>
+                                            <input value="{{ old('price', isset($product) ? Currency::formatForForm($product->price) : '') }}" id="price"
+                                                name="price" step=". 0001" type="number"
+                                                class="form-control @error('price') is-invalid @enderror"
+                                                required="required">
+                                            @error('price')
+                                                <div class="invalid-feedback">
+                                                    {{ $message }}
+                                                </div>
+                                            @enderror
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="minimum_credits">{{ __('Minimum') }} {{ $credits_display_name }}
+                                                <i data-toggle="popover" data-trigger="hover"
+                                                    data-content="{{ __('Setting to empty will use the value from configuration.') }}"
+                                                    class="fas fa-info-circle"></i></label>
+                                            <input
+                                                value="{{ old('minimum_credits', (isset($product) && $product->minimum_credits) ? Currency::formatForForm($product->minimum_credits) : null) }}"
+                                                id="minimum_credits" name="minimum_credits" type="number"
+                                                class="form-control @error('minimum_credits') is-invalid @enderror">
+                                            @error('minimum_credits')
+                                                <div class="invalid-feedback">
+                                                    {{ $message }}
+                                                </div>
+                                            @enderror
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="cpu">{{ __('Cpu') }}</label>
+                                            <input value="{{ $product->cpu ?? old('cpu') }}" id="cpu" name="cpu"
+                                                type="number" class="form-control @error('cpu') is-invalid @enderror"
+                                                required="required">
+                                            @error('cpu')
+                                                <div class="invalid-feedback">
+                                                    {{ $message }}
+                                                </div>
+                                            @enderror
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="disk">{{ __('Disk') }}</label>
+                                            <input value="{{ $product->disk ?? (old('disk') ?? 1000) }}" id="disk"
+                                                name="disk" type="number"
+                                                class="form-control @error('disk') is-invalid @enderror"
+                                                required="required">
+                                            @error('disk')
+                                                <div class="invalid-feedback">
+                                                    {{ $message }}
+                                                </div>
+                                            @enderror
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="memory">{{ __('Memory') }}</label>
+                                            <input value="{{ $product->memory ?? old('memory') }}" id="memory"
+                                                name="memory" type="number"
+                                                class="form-control @error('memory') is-invalid @enderror"
+                                                required="required">
+                                            @error('memory')
+                                                <div class="invalid-feedback">
+                                                    {{ $message }}
+                                                </div>
+                                            @enderror
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="io">{{ __('IO') }}</label>
+                                            <input value="{{ $product->io ?? (old('io') ?? 500) }}" id="io"
+                                                name="io" type="number"
+                                                class="form-control @error('io') is-invalid @enderror"
+                                                required="required">
+                                            @error('io')
+                                                <div class="invalid-feedback">
+                                                    {{ $message }}
+                                                </div>
+                                            @enderror
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="swap">{{ __('Swap') }}</label>
+                                            <input value="{{ $product->swap ?? old('swap') }}" id="swap"
+                                                name="swap" type="number"
+                                                class="form-control @error('swap') is-invalid @enderror"
+                                                required="required">
+                                            @error('swap')
+                                                <div class="invalid-feedback">
+                                                    {{ $message }}
+                                                </div>
+                                            @enderror
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <label for="serverlimit">{{ __('Server limit') }}</label>
+                                            <i
+                                                data-toggle="popover"
+                                                data-trigger="hover"
+                                                data-content="{{ __('The maximum amount of Servers that can be created with this Product per User') }}"
+                                                class="fas fa-info-circle">
+                                            </i>
+                                            <input value="{{ $product->serverlimit ?? (old('serverlimit') ?? 0) }}"
+                                                id="serverlimit" name="serverlimit" type="number"
+                                                class="form-control @error('serverlimit') is-invalid @enderror"
+                                                required="required">
+                                            @error('serverlimit')
+                                                <div class="invalid-feedback">
+                                                    {{ $message }}
+                                                </div>
+                                            @enderror
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col-lg-4">
+                                        <div class="form-group">
+                                            <label for="allocations">{{ __('Allocations') }}</label>
+                                            <input value="{{ $product->allocations ??  (old('allocations') ?? 0) }}"
+                                                id="allocations" name="allocations" type="number"
+                                                class="form-control @error('allocations') is-invalid @enderror"
+                                                required="required">
+                                            @error('allocations')
+                                                <div class="invalid-feedback">
+                                                    {{ $message }}
+                                                </div>
+                                            @enderror
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-4">
+                                        <div class="form-group">
+                                            <label for="databases">{{ __('Databases') }}</label>
+                                            <input value="{{ $product->databases ?? (old('databases') ?? 1) }}"
+                                                id="databases" name="databases" type="number"
+                                                class="form-control @error('databases') is-invalid @enderror"
+                                                required="required">
+                                            @error('databases')
+                                                <div class="invalid-feedback">
+                                                    {{ $message }}
+                                                </div>
+                                            @enderror
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-4">
+                                        <div class="form-group">
+                                            <label for="backups">{{ __('Backups') }}</label>
+                                            <input value="{{ $product->backups ?? (old('backups') ?? 1) }}"
+                                                id="backups" name="backups" type="number"
+                                                class="form-control @error('backups') is-invalid @enderror"
+                                                required="required">
+                                            @error('backups')
+                                                <div class="invalid-feedback">
+                                                    {{ $message }}
+                                                </div>
+                                            @enderror
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="row">
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <input type="checkbox" value="1" id="oom_killer" name="oom_killer">
+                                            <label for="oom_killer">
+                                                {{ __('OOM Killer') }}
+                                                <i data-toggle="popover"
+                                                    data-trigger="hover"
+                                                    data-content="{{ __('Enable or Disable the OOM Killer for this Product. ') }}"
+                                                    class="fas fa-info-circle">
+                                                </i>
+                                            </label>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="text-right form-group">
+                                    <button type="submit" class="btn btn-primary">
+                                        {{ __('Submit') }}
+                                    </button>
+                                </div>
+
+                            </div>
+                        </div>
                     </div>
-                  @enderror
-                  <div class="text-muted">
-                    {{ __('This product will only be available for these nodes') }}
-                  </div>
+
+                    <div class="col-lg-6">
+                        <div class="card">
+                            <div class="card-header">
+                                <h5 class="card-title">{{ __('Product Linking') }}
+                                    <i data-toggle="popover" data-trigger="hover"
+                                        data-content="{{ __('Link your products to nodes and eggs to create dynamic pricing for each option') }}"
+                                        class="fas fa-info-circle"></i>
+                                </h5>
+                            </div>
+                            <div class="card-body">
+
+                                <div class="form-group">
+                                    <label for="nodes">{{ __('Nodes') }}</label>
+                                    <select id="nodes" style="width:100%"
+                                        class="custom-select @error('nodes') is-invalid @enderror" name="nodes[]"
+                                        multiple="multiple" autocomplete="off">
+                                        @foreach ($locations as $location)
+                                            <optgroup label="{{ $location->name }}">
+                                                @foreach ($location->nodes as $node)
+                                                    <option
+                                                        @if (isset($product)) @if ($product->nodes->contains('id', $node->id)) selected @endif
+                                                        @endif
+                                                        value="{{ $node->id }}">{{ $node->name }}</option>
+                                                @endforeach
+                                            </optgroup>
+                                        @endforeach
+                                    </select>
+                                    @error('nodes')
+                                        <div class="text-danger">
+                                            {{ $message }}
+                                        </div>
+                                    @enderror
+                                    <div class="text-muted">
+                                        {{ __('This product will only be available for these nodes') }}
+                                    </div>
+                                </div>
+
+
+                                <div class="form-group">
+                                    <div class="mb-2 d-flex justify-content-between align-items-center">
+                                        <label for="eggs" class="mb-0">{{ __('Eggs') }}</label>
+                                        <div>
+                                            <button type="button" id="select-all-eggs" class="btn btn-sm btn-secondary">{{ __('Select All') }}</button>
+                                            <button type="button" id="deselect-all-eggs" class="ml-2 btn btn-sm btn-secondary">{{ __('Deselect All') }}</button>
+                                        </div>
+                                    </div>
+                                    <select id="eggs" style="width: 100%"
+                                        class="custom-select @error('eggs') is-invalid @enderror" name="eggs[]"
+                                        multiple="multiple" autocomplete="off">
+                                        @foreach ($nests as $nest)
+                                            <optgroup label="{{ $nest->name }}" class="nest-group" data-nest-id="{{ $nest->id }}">
+                                                @foreach ($nest->eggs as $egg)
+                                                    <option class="egg-option" data-nest-id="{{ $nest->id }}"
+                                                        @if (isset($product)) @if ($product->eggs->contains('id', $egg->id)) selected @endif
+                                                        @endif
+                                                        value="{{ $egg->id }}">{{ $egg->name }}</option>
+                                                @endforeach
+                                            </optgroup>
+                                        @endforeach
+                                    </select>
+                                    @error('eggs')
+                                        <div class="text-danger">
+                                            {{ $message }}
+                                        </div>
+                                    @enderror
+                                    <div class="text-muted">
+                                        {{ __('This product will only be available for these eggs') }}
+                                    </div>
+                                </div>
+                                <div class="text-muted">
+                                    {{ __('No Eggs or Nodes shown? ') }} <a
+                                        href="{{ route('admin.overview. sync') }}">{{ __('Sync now') }}</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
                 </div>
 
-
-                <div class="form-group">
-                  <div class="mb-2 d-flex justify-content-between align-items-center">
-                    <label for="eggs" class="mb-0">{{ __('Eggs') }}</label>
-                    <div>
-                      <button type="button" id="select-all-eggs"
-                        class="btn btn-sm btn-secondary">{{ __('Select All') }}</button>
-                      <button type="button" id="deselect-all-eggs"
-                        class="ml-2 btn btn-sm btn-secondary">{{ __('Deselect All') }}</button>
-                    </div>
-                  </div>
-                  <select id="eggs" style="width:100%" class="custom-select @error('eggs') is-invalid @enderror"
-                    name="eggs[]" multiple="multiple" autocomplete="off">
-                    @foreach ($nests as $nest)
-                      <optgroup label="{{ $nest->name }}">
-                        @foreach ($nest->eggs as $egg)
-                          <option @if (isset($product)) @if ($product->eggs->contains('id', $egg->id)) selected @endif @endif
-                            value="{{ $egg->id }}">{{ $egg->name }}</option>
-                        @endforeach
-                      </optgroup>
-                    @endforeach
-                  </select>
-                  @error('eggs')
-                    <div class="text-danger">
-                      {{ $message }}
-                    </div>
-                  @enderror
-                  <div class="text-muted">
-                    {{ __('This product will only be available for these eggs') }}
-                  </div>
-                </div>
-                <div class="text-muted">
-                  {{ __('No Eggs or Nodes shown?') }} <a
-                    href="{{ route('admin.overview.sync') }}">{{ __('Sync now') }}</a>
-                </div>
-              </div>
-            </div>
-          </div>
+                <input type="hidden" name="_token" value="{{ csrf_token() }}">
+            </form>
 
         </div>
+    </section>
 
-        <input type="hidden" name="_token" value="{{ csrf_token() }}">
-      </form>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            $('[data-toggle="popover"]').popover();
+            $('.custom-select').select2({
+                minimumResultsForSearch: -1,
+                closeOnSelect: false
+            });
 
-    </div>
-  </section>
-  <!-- END CONTENT -->
+            $(document).on('click', '.select2-results__group', function(e) {
+                const nestLabel = $(this).text().trim();
+                const $select = $('#eggs');
+                const allOptions = $select.find('option');
 
-  <script>
-    document.addEventListener('DOMContentLoaded', function () {
-      $('[data-toggle="popover"]').popover();
-      $('.custom-select').select2({
-        minimumResultsForSearch: -1
-      });
+                const groupOptions = allOptions.filter(function() {
+                    const $this = $(this);
+                    const $group = $this.closest('optgroup');
+                    return $group.length && $group.attr('label') === nestLabel;
+                });
 
-      document.getElementById('select-all-eggs').addEventListener('click', function () {
-        $('#eggs option').prop('selected', true);
-        $('#eggs').trigger('change');
-      });
+                const allSelected = groupOptions.length > 0 && groupOptions.length === groupOptions.filter(': selected').length;
 
-      document.getElementById('deselect-all-eggs').addEventListener('click', function () {
-        $('#eggs option').prop('selected', false);
-        $('#eggs').trigger('change');
-      });
-    });
-  </script>
+                groupOptions.prop('selected', ! allSelected);
+                $select.trigger('change');
+
+                e.stopPropagation();
+                return false;
+            });
+
+            document.getElementById('select-all-eggs').addEventListener('click', function(e) {
+                e.preventDefault();
+                $('#eggs option').prop('selected', true);
+                $('#eggs').trigger('change');
+            });
+
+            document.getElementById('deselect-all-eggs').addEventListener('click', function(e) {
+                e.preventDefault();
+                $('#eggs option').prop('selected', false);
+                $('#eggs').trigger('change');
+            });
+        });
+    </script>
 @endsection

--- a/themes/default/views/admin/products/edit.blade.php
+++ b/themes/default/views/admin/products/edit.blade.php
@@ -303,6 +303,17 @@
         </div>
     </section>
 
+    <style>
+        .select2-results__group {
+            cursor: pointer !important;
+            transition: background-color 0.2s;
+        }
+        .select2-results__group:hover {
+            background-color: #007bff;
+            color: #ffffff;
+        }
+    </style>
+
     <script>
         document.addEventListener('DOMContentLoaded', (event) => {
             $('[data-toggle="popover"]').popover();

--- a/themes/default/views/admin/products/edit.blade.php
+++ b/themes/default/views/admin/products/edit.blade.php
@@ -1,7 +1,6 @@
 @extends('layouts.main')
 
 @section('content')
-    <!-- CONTENT HEADER -->
     <section class="content-header">
         <div class="container-fluid">
             <div class="mb-2 row">
@@ -11,18 +10,14 @@
                 <div class="col-sm-6">
                     <ol class="breadcrumb float-sm-right">
                         <li class="breadcrumb-item"><a href="{{ route('home') }}">{{ __('Dashboard') }}</a></li>
-                        <li class="breadcrumb-item"><a href="{{ route('admin.products.index') }}">{{ __('Products') }}</a>
-                        </li>
-                        <li class="breadcrumb-item"><a class="text-muted"
-                                href="{{ route('admin.products.edit', $product->id) }}">{{ __('Edit') }}</a>
-                        </li>
+                        <li class="breadcrumb-item"><a href="{{ route('admin.products.index') }}">{{ __('Products') }}</a></li>
+                        <li class="breadcrumb-item"><a class="text-muted" href="{{ route('admin.products.edit', $product->id) }}">{{ __('Edit') }}</a></li>
                     </ol>
                 </div>
             </div>
         </div>
     </section>
 
-    <!-- MAIN CONTENT -->
     <section class="content">
         <div class="container-fluid">
             <form action="{{ route('admin.products.update', $product->id) }}" method="POST">
@@ -31,7 +26,6 @@
 
                 <div class="row">
                     <div class="col-lg-6">
-
                         @if ($product->servers()->count() > 0)
                             <div class="callout callout-danger">
                                 <h4>{{ __('Editing the resource options will not automatically update the servers on pterodactyls side!') }}</h4>
@@ -43,16 +37,12 @@
                                 <h5 class="card-title">{{ __('Product Details') }}</h5>
                             </div>
                             <div class="card-body">
-
                                 <div class="flex-row-reverse d-flex">
                                     <div class="custom-control custom-switch">
-                                        <input type="checkbox" @if ($product->disabled) checked @endif
-                                            name="disabled" class="custom-control-input custom-control-input-danger"
-                                            id="switch1">
-                                        <label class="custom-control-label" for="switch1">{{ __('Disabled') }} <i
-                                                data-toggle="popover" data-trigger="hover"
-                                                data-content="{{ __('Will hide this option from being selected') }}"
-                                                class="fas fa-info-circle"></i></label>
+                                        <input type="checkbox" @checked($product->disabled) name="disabled" class="custom-control-input custom-control-input-danger" id="switch1">
+                                        <label class="custom-control-label" for="switch1">{{ __('Disabled') }} 
+                                            <i data-toggle="popover" data-trigger="hover" data-content="{{ __('Will hide this option from being selected') }}" class="fas fa-info-circle"></i>
+                                        </label>
                                     </div>
                                 </div>
 
@@ -60,283 +50,194 @@
                                     <div class="col-lg-12">
                                         <div class="form-group">
                                             <label for="name">{{ __('Name') }}</label>
-                                            <input value="{{ $product->name }}" id="name" name="name"
-                                                type="text" class="form-control @error('name') is-invalid @enderror"
-                                                required="required">
+                                            <input value="{{ $product->name }}" id="name" name="name" type="text" class="form-control @error('name') is-invalid @enderror" required="required">
                                             @error('name')
-                                                <div class="invalid-feedback">
-                                                    {{ $message }}
-                                                </div>
+                                                <div class="invalid-feedback">{{ $message }}</div>
                                             @enderror
                                         </div>
                                     </div>
                                     <div class="col-lg-12">
                                         <div class="form-group">
-                                            <label for="description">{{ __('Description') }} <i data-toggle="popover"
-                                                    data-trigger="hover"
-                                                    data-content="{{ __('This is what the users sees') }}"
-                                                    class="fas fa-info-circle"></i></label>
-                                            <textarea id="description" name="description" type="text"
-                                                class="form-control @error('description') is-invalid @enderror" required="required">{{ $product->description }}</textarea>
+                                            <label for="description">{{ __('Description') }} 
+                                                <i data-toggle="popover" data-trigger="hover" data-content="{{ __('This is what the users sees') }}" class="fas fa-info-circle"></i>
+                                            </label>
+                                            <textarea id="description" name="description" type="text" class="form-control @error('description') is-invalid @enderror" required="required">{{ $product->description }}</textarea>
                                             @error('description')
-                                                <div class="invalid-feedback">
-                                                    {{ $message }}
-                                                </div>
+                                                <div class="invalid-feedback">{{ $message }}</div>
                                             @enderror
                                         </div>
                                     </div>
                                 </div>
+
                                 <div class="row">
                                     <div class="col-lg-6">
                                         <div class="form-group">
-                                            <label for="billing_period">{{ __('Billing Period') }} <i
-                                                    data-toggle="popover" data-trigger="hover"
-                                                    data-content="{{ __('Period when the user will be charged for the given price') }}"
-                                                    class="fas fa-info-circle"></i></label>
-
-                                            <select id="billing_period" style="width:100%" class="custom-select"
-                                                name="billing_period" required autocomplete="off"
-                                                @error('billing_period') is-invalid @enderror>
-                                                <option value="hourly" @selected($product->billing_period == 'hourly')>
-                                                    {{ __('Hourly') }}
-                                                </option>
-                                                <option value="daily" @selected($product->billing_period == 'daily')>
-                                                    {{ __('Daily') }}
-                                                </option>
-                                                <option value="weekly" @selected($product->billing_period == 'weekly')>
-                                                    {{ __('Weekly') }}
-                                                </option>
-                                                <option value="monthly" @selected($product->billing_period == 'monthly')>
-                                                    {{ __('Monthly') }}
-                                                </option>
-                                                <option value="quarterly" @selected($product->billing_period == 'quarterly')>
-                                                    {{ __('Quarterly') }}
-                                                </option>
-                                                <option value="half-annually" @selected($product->billing_period == 'half-annually')>
-                                                    {{ __('Half Annually') }}
-                                                </option>
-                                                <option value="annually" @selected($product->billing_period == 'annually')>
-                                                    {{ __('Annually') }}
-                                                </option>
+                                            <label for="billing_period">{{ __('Billing Period') }} 
+                                                <i data-toggle="popover" data-trigger="hover" data-content="{{ __('Period when the user will be charged for the given price') }}" class="fas fa-info-circle"></i>
+                                            </label>
+                                            <select id="billing_period" style="width:100%" class="custom-select" name="billing_period" required autocomplete="off">
+                                                <option value="hourly" @selected($product->billing_period == 'hourly')>{{ __('Hourly') }}</option>
+                                                <option value="daily" @selected($product->billing_period == 'daily')>{{ __('Daily') }}</option>
+                                                <option value="weekly" @selected($product->billing_period == 'weekly')>{{ __('Weekly') }}</option>
+                                                <option value="monthly" @selected($product->billing_period == 'monthly')>{{ __('Monthly') }}</option>
+                                                <option value="quarterly" @selected($product->billing_period == 'quarterly')>{{ __('Quarterly') }}</option>
+                                                <option value="half-annually" @selected($product->billing_period == 'half-annually')>{{ __('Half Annually') }}</option>
+                                                <option value="annually" @selected($product->billing_period == 'annually')>{{ __('Annually') }}</option>
                                             </select>
                                             @error('billing_period')
-                                                <div class="invalid-feedback">
-                                                    {{ $message }}
-                                                </div>
+                                                <div class="invalid-feedback">{{ $message }}</div>
                                             @enderror
                                         </div>
                                     </div>
                                     <div class="col-lg-6">
                                         <div class="form-group">
-                                            <label for="default_billing_priority">
-                                                {{ __('Default Billing Priority') }}
-                                                <i
-                                                    data-toggle="popover"
-                                                    data-trigger="hover"
-                                                    data-content="{{ __('Defines the priority at which the servers in this product will be charged.') }}"
-                                                    class="fas fa-info-circle"></i>
+                                            <label for="default_billing_priority">{{ __('Default Billing Priority') }}
+                                                <i data-toggle="popover" data-trigger="hover" data-content="{{ __('Defines the priority at which the servers in this product will be charged.') }}" class="fas fa-info-circle"></i>
                                             </label>
-                                            <select
-                                                id="default_billing_priority" style="width:100%" class="custom-select"
-                                                name="default_billing_priority" required autocomplete="off"
-                                                @error('default_billing_priority') is-invalid @enderror
-                                            >
+                                            <select id="default_billing_priority" style="width:100%" class="custom-select" name="default_billing_priority" required autocomplete="off">
                                                 @foreach(App\Enums\BillingPriority::options() as $value => $label)
-                                                    <option value="{{ $value }}" @selected($product->default_billing_priority->value == $value)>
-                                                        {{ $label }}
-                                                    </option>
+                                                    <option value="{{ $value }}" @selected($product->default_billing_priority->value == $value)>{{ $label }}</option>
                                                 @endforeach
                                             </select>
                                             @error('default_billing_priority')
-                                                <div class="invalid-feedback">
-                                                    {{ $message }}
-                                                </div>
+                                                <div class="invalid-feedback">{{ $message }}</div>
                                             @enderror
                                         </div>
                                     </div>
                                 </div>
+
                                 <div class="row">
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="price">{{ __('Price in') }} {{ $credits_display_name }}</label>
-                                            <input value="{{ Currency::formatForForm($product->price) }}" id="price" name="price"
-                                                type="number" step=".0001"
-                                                class="form-control @error('price') is-invalid @enderror"
-                                                required="required">
+                                            <input value="{{ Currency::formatForForm($product->price) }}" id="price" name="price" type="number" step="0.0001" class="form-control @error('price') is-invalid @enderror" required="required">
                                             @error('price')
-                                                <div class="invalid-feedback">
-                                                    {{ $message }}
-                                                </div>
+                                                <div class="invalid-feedback">{{ $message }}</div>
                                             @enderror
                                         </div>
                                     </div>
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="minimum_credits">{{ __('Minimum') }} {{ $credits_display_name }}
-                                                <i data-toggle="popover" data-trigger="hover"
-                                                    data-content="{{ __('Setting to empty will use the value from configuration.') }}"
-                                                    class="fas fa-info-circle"></i></label>
-                                            <input value="{{ $product->minimum_credits ? Currency::formatForForm($product->minimum_credits) : null }}" id="minimum_credits"
-                                                name="minimum_credits" type="number"
-                                                class="form-control @error('minimum_credits') is-invalid @enderror">
+                                                <i data-toggle="popover" data-trigger="hover" data-content="{{ __('Setting to empty will use the value from configuration.') }}" class="fas fa-info-circle"></i>
+                                            </label>
+                                            <input value="{{ $product->minimum_credits ? Currency::formatForForm($product->minimum_credits) : null }}" id="minimum_credits" name="minimum_credits" type="number" step="0.0001" class="form-control @error('minimum_credits') is-invalid @enderror">
                                             @error('minimum_credits')
-                                                <div class="invalid-feedback">
-                                                    {{ $message }}
-                                                </div>
+                                                <div class="invalid-feedback">{{ $message }}</div>
                                             @enderror
                                         </div>
                                     </div>
                                 </div>
+
                                 <div class="row">
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="cpu">{{ __('Cpu') }}</label>
-                                            <input value="{{ $product->cpu }}" id="cpu" name="cpu" type="number"
-                                                class="form-control @error('cpu') is-invalid @enderror" required="required">
+                                            <input value="{{ $product->cpu }}" id="cpu" name="cpu" type="number" class="form-control @error('cpu') is-invalid @enderror" required="required">
                                             @error('cpu')
-                                                <div class="invalid-feedback">
-                                                    {{ $message }}
-                                                </div>
+                                                <div class="invalid-feedback">{{ $message }}</div>
                                             @enderror
                                         </div>
                                     </div>
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="disk">{{ __('Disk') }}</label>
-                                            <input value="{{ $product->disk }}" id="disk" name="disk"
-                                                type="number" class="form-control @error('disk') is-invalid @enderror"
-                                                required="required">
+                                            <input value="{{ $product->disk }}" id="disk" name="disk" type="number" class="form-control @error('disk') is-invalid @enderror" required="required">
                                             @error('disk')
-                                                <div class="invalid-feedback">
-                                                    {{ $message }}
-                                                </div>
+                                                <div class="invalid-feedback">{{ $message }}</div>
                                             @enderror
                                         </div>
                                     </div>
                                 </div>
+
                                 <div class="row">
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="memory">{{ __('Memory') }}</label>
-                                            <input value="{{ $product->memory }}" id="memory" name="memory"
-                                                type="number" class="form-control @error('memory') is-invalid @enderror"
-                                                required="required">
+                                            <input value="{{ $product->memory }}" id="memory" name="memory" type="number" class="form-control @error('memory') is-invalid @enderror" required="required">
                                             @error('memory')
-                                                <div class="invalid-feedback">
-                                                    {{ $message }}
-                                                </div>
+                                                <div class="invalid-feedback">{{ $message }}</div>
                                             @enderror
                                         </div>
                                     </div>
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="io">{{ __('IO') }}</label>
-                                            <input value="{{ $product->io }}" id="io" name="io"
-                                                type="number" class="form-control @error('io') is-invalid @enderror"
-                                                required="required">
+                                            <input value="{{ $product->io }}" id="io" name="io" type="number" class="form-control @error('io') is-invalid @enderror" required="required">
                                             @error('io')
-                                                <div class="invalid-feedback">
-                                                    {{ $message }}
-                                                </div>
+                                                <div class="invalid-feedback">{{ $message }}</div>
                                             @enderror
                                         </div>
                                     </div>
                                 </div>
+
                                 <div class="row">
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="swap">{{ __('Swap') }}</label>
-                                            <input value="{{ $product->swap }}" id="swap" name="swap"
-                                                type="number" class="form-control @error('swap') is-invalid @enderror"
-                                                required="required">
+                                            <input value="{{ $product->swap }}" id="swap" name="swap" type="number" class="form-control @error('swap') is-invalid @enderror" required="required">
                                             @error('swap')
-                                                <div class="invalid-feedback">
-                                                    {{ $message }}
-                                                </div>
+                                                <div class="invalid-feedback">{{ $message }}</div>
                                             @enderror
                                         </div>
                                     </div>
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="serverlimit">{{ __('Server limit') }}</label>
-                                            <i data-toggle="popover" data-trigger="hover"
-                                            data-content="{{ __('The maximum amount of Servers that can be created with this Product per User. 0 = unlimited') }}"
-                                            class="fas fa-info-circle"></i>
-                                            <input value="{{ $product->serverlimit ?? 0 }}"
-                                                id="serverlimit" name="serverlimit" type="number"
-                                                class="form-control @error('serverlimit') is-invalid @enderror"
-                                                required="required">
+                                            <i data-toggle="popover" data-trigger="hover" data-content="{{ __('The maximum amount of Servers that can be created with this Product per User. 0 = unlimited') }}" class="fas fa-info-circle"></i>
+                                            <input value="{{ $product->serverlimit ?? 0 }}" id="serverlimit" name="serverlimit" type="number" class="form-control @error('serverlimit') is-invalid @enderror" required="required">
                                             @error('serverlimit')
-                                                <div class="invalid-feedback">
-                                                    {{ $message }}
-                                                </div>
+                                                <div class="invalid-feedback">{{ $message }}</div>
                                             @enderror
-                                      </div>
+                                        </div>
                                     </div>
                                 </div>
+
                                 <div class="row">
                                     <div class="col-lg-4">
                                         <div class="form-group">
                                             <label for="allocations">{{ __('Allocations') }}</label>
-                                            <input value="{{ $product->allocations ?? (old('allocations') ?? 0) }}"
-                                                id="allocations" name="allocations" type="number"
-                                                class="form-control @error('allocations') is-invalid @enderror"
-                                                required="required">
+                                            <input value="{{ $product->allocations ?? 0 }}" id="allocations" name="allocations" type="number" class="form-control @error('allocations') is-invalid @enderror" required="required">
                                             @error('allocations')
-                                                <div class="invalid-feedback">
-                                                    {{ $message }}
-                                                </div>
+                                                <div class="invalid-feedback">{{ $message }}</div>
                                             @enderror
                                         </div>
                                     </div>
                                     <div class="col-lg-4">
                                         <div class="form-group">
                                             <label for="databases">{{ __('Databases') }}</label>
-                                            <input value="{{ $product->databases ?? (old('databases') ?? 1) }}"
-                                                id="databases" name="databases" type="number"
-                                                class="form-control @error('databases') is-invalid @enderror"
-                                                required="required">
+                                            <input value="{{ $product->databases ?? 1 }}" id="databases" name="databases" type="number" class="form-control @error('databases') is-invalid @enderror" required="required">
                                             @error('databases')
-                                                <div class="invalid-feedback">
-                                                    {{ $message }}
-                                                </div>
+                                                <div class="invalid-feedback">{{ $message }}</div>
                                             @enderror
                                         </div>
                                     </div>
                                     <div class="col-lg-4">
                                         <div class="form-group">
                                             <label for="backups">{{ __('Backups') }}</label>
-                                            <input value="{{ $product->backups ?? (old('backups') ?? 1) }}"
-                                                id="backups" name="backups" type="number"
-                                                class="form-control @error('backups') is-invalid @enderror"
-                                                required="required">
+                                            <input value="{{ $product->backups ?? 1 }}" id="backups" name="backups" type="number" class="form-control @error('backups') is-invalid @enderror" required="required">
                                             @error('backups')
-                                                <div class="invalid-feedback">
-                                                    {{ $message }}
-                                                </div>
+                                                <div class="invalid-feedback">{{ $message }}</div>
                                             @enderror
                                         </div>
                                     </div>
                                 </div>
+
                                 <div class="row">
                                     <div class="col-lg-6">
                                         <div class="form-group">
-                                            <input type="checkbox" value="1" id="oom_killer" name="oom_killer" @if ($product->oom_killer) checked @endif>
-                                            <label for="oom_killer">
-                                                {{ __('OOM Killer') }}
-                                                <i data-toggle="popover"
-                                                    data-trigger="hover"
-                                                    data-content="{{ __('Enable or Disable the OOM Killer for this Product.') }}"
-                                                    class="fas fa-info-circle">
-                                                </i>
-                                            </label>
+                                            <div class="custom-control custom-checkbox">
+                                                <input type="checkbox" class="custom-control-input" value="1" id="oom_killer" name="oom_killer" @checked($product->oom_killer)>
+                                                <label class="custom-control-label" for="oom_killer">{{ __('OOM Killer') }}
+                                                    <i data-toggle="popover" data-trigger="hover" data-content="{{ __('Enable or Disable the OOM Killer for this Product.') }}" class="fas fa-info-circle"></i>
+                                                </label>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
+
                                 <div class="text-right form-group">
-                                    <button type="submit" class="btn btn-primary">
-                                        {{ __('Submit') }}
-                                    </button>
+                                    <button type="submit" class="btn btn-primary">{{ __('Submit') }}</button>
                                 </div>
                             </div>
                         </div>
@@ -346,35 +247,25 @@
                         <div class="card">
                             <div class="card-header">
                                 <h5 class="card-title">{{ __('Product Linking') }}
-                                    <i data-toggle="popover" data-trigger="hover"
-                                        data-content="{{ __('Link your products to nodes and eggs to create dynamic pricing for each option') }}"
-                                        class="fas fa-info-circle"></i>
+                                    <i data-toggle="popover" data-trigger="hover" data-content="{{ __('Link your products to nodes and eggs to create dynamic pricing for each option') }}" class="fas fa-info-circle"></i>
                                 </h5>
                             </div>
                             <div class="card-body">
-
                                 <div class="form-group">
                                     <label for="nodes">{{ __('Nodes') }}</label>
-                                    <select id="nodes" style="width:100%"
-                                        class="custom-select @error('nodes') is-invalid @enderror" name="nodes[]"
-                                        multiple="multiple" autocomplete="off">
+                                    <select id="nodes" style="width:100%" class="custom-select @error('nodes') is-invalid @enderror" name="nodes[]" multiple="multiple" autocomplete="off">
                                         @foreach ($locations as $location)
                                             <optgroup label="{{ $location->name }}">
                                                 @foreach ($location->nodes as $node)
-                                                    <option @if ($product->nodes->contains('id', $node->id)) selected @endif
-                                                        value="{{ $node->id }}">{{ $node->name }}</option>
+                                                    <option value="{{ $node->id }}" @selected($product->nodes->contains('id', $node->id))>{{ $node->name }}</option>
                                                 @endforeach
                                             </optgroup>
                                         @endforeach
                                     </select>
                                     @error('nodes')
-                                        <div class="text-danger">
-                                            {{ $message }}
-                                        </div>
+                                        <div class="text-danger">{{ $message }}</div>
                                     @enderror
-                                    <div class="text-muted">
-                                        {{ __('This product will only be available for these nodes') }}
-                                    </div>
+                                    <div class="text-muted">{{ __('This product will only be available for these nodes') }}</div>
                                 </div>
 
                                 <div class="form-group">
@@ -385,32 +276,26 @@
                                             <button type="button" id="deselect-all-eggs" class="ml-2 btn btn-sm btn-secondary">{{ __('Deselect All') }}</button>
                                         </div>
                                     </div>
-                                    <select id="eggs" style="width:100%"
-                                        class="custom-select @error('eggs') is-invalid @enderror" name="eggs[]"
-                                        multiple="multiple" autocomplete="off">
+                                    <select id="eggs" style="width:100%" class="custom-select @error('eggs') is-invalid @enderror" name="eggs[]" multiple="multiple" autocomplete="off">
                                         @foreach ($nests as $nest)
                                             <optgroup label="{{ $nest->name }}" class="nest-group" data-nest-id="{{ $nest->id }}">
                                                 @foreach ($nest->eggs as $egg)
-                                                    <option class="egg-option" data-nest-id="{{ $nest->id }}" @if ($product->eggs->contains('id', $egg->id)) selected @endif
-                                                        value="{{ $egg->id }}">{{ $egg->name }}</option>
+                                                    <option class="egg-option" data-nest-id="{{ $nest->id }}" value="{{ $egg->id }}" @selected($product->eggs->contains('id', $egg->id))>{{ $egg->name }}</option>
                                                 @endforeach
                                             </optgroup>
                                         @endforeach
                                     </select>
                                     @error('eggs')
-                                        <div class="text-danger">
-                                            {{ $message }}
-                                        </div>
+                                        <div class="text-danger">{{ $message }}</div>
                                     @enderror
-                                    <div class="text-muted">
-                                        {{ __('This product will only be available for these eggs') }}
-                                    </div>
+                                    <div class="text-muted">{{ __('This product will only be available for these eggs') }}</div>
                                 </div>
-
+                                <div class="text-muted">
+                                    {{ __('No Eggs or Nodes shown? ') }} <a href="{{ route('admin.overview.sync') }}">{{ __('Sync now') }}</a>
+                                </div>
                             </div>
                         </div>
                     </div>
-
                 </div>
 
                 <input type="hidden" name="_token" value="{{ csrf_token() }}">
@@ -421,37 +306,34 @@
     <script>
         document.addEventListener('DOMContentLoaded', (event) => {
             $('[data-toggle="popover"]').popover();
+            
             $('.custom-select').select2({
                 minimumResultsForSearch: -1,
                 closeOnSelect: false
             });
 
-            // Logic to select all items in a group when the group label is clicked
             $(document).on('click', '.select2-results__group', function(e) {
-                const nestLabel = $(this).text().trim();
-                const $select = $('#eggs');
-                const allOptions = $select.find('option');
-
-                // Find all options that belong to this group (optgroup)
-                const groupOptions = allOptions.filter(function() {
-                    const $this = $(this);
-                    const $group = $this.closest('optgroup');
-                    return $group.length && $group.attr('label') === nestLabel;
+                var groupName = $(this).text();
+                var $select = $('#eggs');
+                
+                var options = $select.find('option');
+                
+                var groupOptions = options.filter(function() {
+                    return $(this).closest('optgroup').attr('label') === groupName;
                 });
 
-                // Check if all are already selected
-                const allSelected = groupOptions.length > 0 && groupOptions.length === groupOptions.filter(':selected').length;
+                var allSelected = true;
+                groupOptions.each(function() {
+                    if (!$(this).prop('selected')) {
+                        allSelected = false;
+                        return false;
+                    }
+                });
 
-                // Toggle selection
                 groupOptions.prop('selected', !allSelected);
-
-                // Trigger change to update Select2 visuals
                 $select.trigger('change');
-
-                // Optional: Select2 usually closes on selection, we might want to keep it open or let it close.
-                // Preventing default keeps the dropdown open if necessary, but Select2 rebuilds DOM on change.
-                e.stopPropagation();
-                return false;
+                $select.select2('close');
+                $select.select2('open');
             });
 
             document.getElementById('select-all-eggs').addEventListener('click', function(e) {
@@ -465,6 +347,6 @@
                 $('#eggs option').prop('selected', false);
                 $('#eggs').trigger('change');
             });
-        })
+        });
     </script>
 @endsection

--- a/themes/default/views/admin/products/edit.blade.php
+++ b/themes/default/views/admin/products/edit.blade.php
@@ -21,7 +21,6 @@
             </div>
         </div>
     </section>
-    <!-- END CONTENT HEADER -->
 
     <!-- MAIN CONTENT -->
     <section class="content">
@@ -35,9 +34,7 @@
 
                         @if ($product->servers()->count() > 0)
                             <div class="callout callout-danger">
-                                <h4>{{ __('Editing the resource options will not automatically update the servers on
-                                                                                                    pterodactyls side!') }}
-                                </h4>
+                                <h4>{{ __('Editing the resource options will not automatically update the servers on pterodactyls side! ') }}</h4>
                             </div>
                         @endif
 
@@ -151,10 +148,10 @@
                                                 @endforeach
                                             </select>
                                             @error('default_billing_priority')
-												<div class="invalid-feedback">
-													{{ $message }}
-												</div>
-											@enderror
+                                                <div class="invalid-feedback">
+                                                    {{ $message }}
+                                                </div>
+                                            @enderror
                                         </div>
                                     </div>
                                 </div>
@@ -163,7 +160,7 @@
                                         <div class="form-group">
                                             <label for="price">{{ __('Price in') }} {{ $credits_display_name }}</label>
                                             <input value="{{ Currency::formatForForm($product->price) }}" id="price" name="price"
-                                                type="number" step=".0001"
+                                                type="number" step=". 0001"
                                                 class="form-control @error('price') is-invalid @enderror"
                                                 required="required">
                                             @error('price')
@@ -177,9 +174,9 @@
                                         <div class="form-group">
                                             <label for="minimum_credits">{{ __('Minimum') }} {{ $credits_display_name }}
                                                 <i data-toggle="popover" data-trigger="hover"
-                                                    data-content="{{ __('Setting to empty will use the value from configuration.') }}"
+                                                    data-content="{{ __('Setting to empty will use the value from configuration. ') }}"
                                                     class="fas fa-info-circle"></i></label>
-                                            <input value="{{ $product->minimum_credits ? Currency::formatForForm($product->minimum_credits) : null }}" id="minimum_credits"
+                                            <input value="{{ $product->minimum_credits ?  Currency::formatForForm($product->minimum_credits) : null }}" id="minimum_credits"
                                                 name="minimum_credits" type="number"
                                                 class="form-control @error('minimum_credits') is-invalid @enderror">
                                             @error('minimum_credits')
@@ -194,9 +191,8 @@
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="cpu">{{ __('Cpu') }}</label>
-                                            <input value="{{ $product->cpu }}" id="cpu" name="cpu" type="number" min="0"
+                                            <input value="{{ $product->cpu }}" id="cpu" name="cpu" type="number"
                                                 class="form-control @error('cpu') is-invalid @enderror" required="required">
-                                            <div class="text-muted small">{{ __('Set to 0 for Unlimited') }}</div>
                                             @error('cpu')
                                                 <div class="invalid-feedback">
                                                     {{ $message }}
@@ -208,9 +204,8 @@
                                         <div class="form-group">
                                             <label for="disk">{{ __('Disk') }}</label>
                                             <input value="{{ $product->disk }}" id="disk" name="disk"
-                                                type="number" min="0" class="form-control @error('disk') is-invalid @enderror"
+                                                type="number" class="form-control @error('disk') is-invalid @enderror"
                                                 required="required">
-                                            <div class="text-muted small">{{ __('Set to 0 for Unlimited') }}</div>
                                             @error('disk')
                                                 <div class="invalid-feedback">
                                                     {{ $message }}
@@ -224,9 +219,8 @@
                                         <div class="form-group">
                                             <label for="memory">{{ __('Memory') }}</label>
                                             <input value="{{ $product->memory }}" id="memory" name="memory"
-                                                type="number" min="0" class="form-control @error('memory') is-invalid @enderror"
+                                                type="number" class="form-control @error('memory') is-invalid @enderror"
                                                 required="required">
-                                            <div class="text-muted small">{{ __('Set to 0 for Unlimited') }}</div>
                                             @error('memory')
                                                 <div class="invalid-feedback">
                                                     {{ $message }}
@@ -255,7 +249,6 @@
                                             <input value="{{ $product->swap }}" id="swap" name="swap"
                                                 type="number" class="form-control @error('swap') is-invalid @enderror"
                                                 required="required">
-                                              <div class="text-muted small">{{ __('Set to -1 for Unlimited') }}</div>
                                             @error('swap')
                                                 <div class="invalid-feedback">
                                                     {{ $message }}
@@ -265,9 +258,9 @@
                                     </div>
                                     <div class="col-lg-6">
                                         <div class="form-group">
-                                            <label for="serverlimit">{{ __('Serverlimit') }}</label>
+                                            <label for="serverlimit">{{ __('Server limit') }}</label>
                                             <i data-toggle="popover" data-trigger="hover"
-                                            data-content="{{ __('The maximum amount of Servers that can be created with this Product per User. 0 = unlimited') }}"
+                                            data-content="{{ __('The maximum amount of Servers that can be created with this Product per User.  0 = unlimited') }}"
                                             class="fas fa-info-circle"></i>
                                             <input value="{{ $product->serverlimit ??  0 }}"
                                                 id="serverlimit" name="serverlimit" type="number"
@@ -283,53 +276,53 @@
                                 </div>
                                 <div class="row">
                                     <div class="col-lg-4">
-										<div class="form-group">
-											<label for="allocations">{{ __('Allocations') }}</label>
-											<input value="{{ $product->allocations ?? (old('allocations') ?? 0) }}"
-												id="allocations" name="allocations" type="number"
-												class="form-control @error('allocations') is-invalid @enderror"
-												required="required">
-											@error('allocations')
-												<div class="invalid-feedback">
-													{{ $message }}
-												</div>
-											@enderror
-										</div>
-									</div>
-									<div class="col-lg-4">
-										<div class="form-group">
-											<label for="databases">{{ __('Databases') }}</label>
-											<input value="{{ $product->databases ?? (old('databases') ?? 1) }}"
-												id="databases" name="databases" type="number"
-												class="form-control @error('databases') is-invalid @enderror"
-												required="required">
-											@error('databases')
-												<div class="invalid-feedback">
-													{{ $message }}
-												</div>
-											@enderror
-										</div>
-									</div>
-									<div class="col-lg-4">
-										<div class="form-group">
-											<label for="backups">{{ __('Backups') }}</label>
-											<input value="{{ $product->backups ?? (old('backups') ?? 1) }}"
-												id="backups" name="backups" type="number"
-												class="form-control @error('backups') is-invalid @enderror"
-												required="required">
-											@error('backups')
-												<div class="invalid-feedback">
-													{{ $message }}
-												</div>
-											@enderror
-										</div>
-									</div>
-								</div>
+                                        <div class="form-group">
+                                            <label for="allocations">{{ __('Allocations') }}</label>
+                                            <input value="{{ $product->allocations ??  (old('allocations') ?? 0) }}"
+                                                id="allocations" name="allocations" type="number"
+                                                class="form-control @error('allocations') is-invalid @enderror"
+                                                required="required">
+                                            @error('allocations')
+                                                <div class="invalid-feedback">
+                                                    {{ $message }}
+                                                </div>
+                                            @enderror
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-4">
+                                        <div class="form-group">
+                                            <label for="databases">{{ __('Databases') }}</label>
+                                            <input value="{{ $product->databases ?? (old('databases') ?? 1) }}"
+                                                id="databases" name="databases" type="number"
+                                                class="form-control @error('databases') is-invalid @enderror"
+                                                required="required">
+                                            @error('databases')
+                                                <div class="invalid-feedback">
+                                                    {{ $message }}
+                                                </div>
+                                            @enderror
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-4">
+                                        <div class="form-group">
+                                            <label for="backups">{{ __('Backups') }}</label>
+                                            <input value="{{ $product->backups ?? (old('backups') ?? 1) }}"
+                                                id="backups" name="backups" type="number"
+                                                class="form-control @error('backups') is-invalid @enderror"
+                                                required="required">
+                                            @error('backups')
+                                                <div class="invalid-feedback">
+                                                    {{ $message }}
+                                                </div>
+                                            @enderror
+                                        </div>
+                                    </div>
+                                </div>
                                 <div class="row">
-									<div class="col-lg-6">
-										<div class="form-group">
-                                            <input type="checkbox" value="1" id="oom_killer" name="oom_killer" @if($product->oom_killer) checked @endif>
-											<label for="oom_killer">
+                                    <div class="col-lg-6">
+                                        <div class="form-group">
+                                            <input type="checkbox" value="1" id="oom_killer" name="oom_killer">
+                                            <label for="oom_killer">
                                                 {{ __('OOM Killer') }}
                                                 <i data-toggle="popover"
                                                     data-trigger="hover"
@@ -337,9 +330,9 @@
                                                     class="fas fa-info-circle">
                                                 </i>
                                             </label>
-										</div>
-									</div>
-								</div>
+                                        </div>
+                                    </div>
+                                </div>
                                 <div class="text-right form-group">
                                     <button type="submit" class="btn btn-primary">
                                         {{ __('Submit') }}
@@ -396,9 +389,9 @@
                                         class="custom-select @error('eggs') is-invalid @enderror" name="eggs[]"
                                         multiple="multiple" autocomplete="off">
                                         @foreach ($nests as $nest)
-                                            <optgroup label="{{ $nest->name }}">
+                                            <optgroup label="{{ $nest->name }}" class="nest-group" data-nest-id="{{ $nest->id }}">
                                                 @foreach ($nest->eggs as $egg)
-                                                    <option @if ($product->eggs->contains('id', $egg->id)) selected @endif
+                                                    <option class="egg-option" data-nest-id="{{ $nest->id }}" @if ($product->eggs->contains('id', $egg->id)) selected @endif
                                                         value="{{ $egg->id }}">{{ $egg->name }}</option>
                                                 @endforeach
                                             </optgroup>
@@ -424,28 +417,46 @@
             </form>
         </div>
     </section>
-    <!-- END CONTENT -->
 
     <script>
         document.addEventListener('DOMContentLoaded', (event) => {
+            $('[data-toggle="popover"]').popover();
             $('.custom-select').select2({
-                minimumResultsForSearch: -1
+                minimumResultsForSearch: -1,
+                closeOnSelect: false
             });
 
-            document.getElementById('select-all-eggs').addEventListener('click', function() {
+            $(document).on('click', '.select2-results__group', function(e) {
+                const nestLabel = $(this).text().trim();
+                const $select = $('#eggs');
+                const allOptions = $select.find('option');
+
+                const groupOptions = allOptions.filter(function() {
+                    const $this = $(this);
+                    const $group = $this.closest('optgroup');
+                    return $group.length && $group.attr('label') === nestLabel;
+                });
+
+                const allSelected = groupOptions. length > 0 && groupOptions.length === groupOptions.filter(':selected').length;
+
+                groupOptions.prop('selected', !allSelected);
+                $select.trigger('change');
+
+                e.stopPropagation();
+                return false;
+            });
+
+            document. getElementById('select-all-eggs').addEventListener('click', function(e) {
+                e.preventDefault();
                 $('#eggs option').prop('selected', true);
                 $('#eggs').trigger('change');
             });
 
-            document.getElementById('deselect-all-eggs').addEventListener('click', function() {
+            document.getElementById('deselect-all-eggs').addEventListener('click', function(e) {
+                e.preventDefault();
                 $('#eggs option').prop('selected', false);
                 $('#eggs').trigger('change');
             });
         })
-    </script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            $('[data-toggle="popover"]').popover();
-        });
     </script>
 @endsection

--- a/themes/default/views/admin/products/edit.blade.php
+++ b/themes/default/views/admin/products/edit.blade.php
@@ -34,7 +34,7 @@
 
                         @if ($product->servers()->count() > 0)
                             <div class="callout callout-danger">
-                                <h4>{{ __('Editing the resource options will not automatically update the servers on pterodactyls side! ') }}</h4>
+                                <h4>{{ __('Editing the resource options will not automatically update the servers on pterodactyls side!') }}</h4>
                             </div>
                         @endif
 
@@ -160,7 +160,7 @@
                                         <div class="form-group">
                                             <label for="price">{{ __('Price in') }} {{ $credits_display_name }}</label>
                                             <input value="{{ Currency::formatForForm($product->price) }}" id="price" name="price"
-                                                type="number" step=". 0001"
+                                                type="number" step=".0001"
                                                 class="form-control @error('price') is-invalid @enderror"
                                                 required="required">
                                             @error('price')
@@ -174,9 +174,9 @@
                                         <div class="form-group">
                                             <label for="minimum_credits">{{ __('Minimum') }} {{ $credits_display_name }}
                                                 <i data-toggle="popover" data-trigger="hover"
-                                                    data-content="{{ __('Setting to empty will use the value from configuration. ') }}"
+                                                    data-content="{{ __('Setting to empty will use the value from configuration.') }}"
                                                     class="fas fa-info-circle"></i></label>
-                                            <input value="{{ $product->minimum_credits ?  Currency::formatForForm($product->minimum_credits) : null }}" id="minimum_credits"
+                                            <input value="{{ $product->minimum_credits ? Currency::formatForForm($product->minimum_credits) : null }}" id="minimum_credits"
                                                 name="minimum_credits" type="number"
                                                 class="form-control @error('minimum_credits') is-invalid @enderror">
                                             @error('minimum_credits')
@@ -260,9 +260,9 @@
                                         <div class="form-group">
                                             <label for="serverlimit">{{ __('Server limit') }}</label>
                                             <i data-toggle="popover" data-trigger="hover"
-                                            data-content="{{ __('The maximum amount of Servers that can be created with this Product per User.  0 = unlimited') }}"
+                                            data-content="{{ __('The maximum amount of Servers that can be created with this Product per User. 0 = unlimited') }}"
                                             class="fas fa-info-circle"></i>
-                                            <input value="{{ $product->serverlimit ??  0 }}"
+                                            <input value="{{ $product->serverlimit ?? 0 }}"
                                                 id="serverlimit" name="serverlimit" type="number"
                                                 class="form-control @error('serverlimit') is-invalid @enderror"
                                                 required="required">
@@ -278,7 +278,7 @@
                                     <div class="col-lg-4">
                                         <div class="form-group">
                                             <label for="allocations">{{ __('Allocations') }}</label>
-                                            <input value="{{ $product->allocations ??  (old('allocations') ?? 0) }}"
+                                            <input value="{{ $product->allocations ?? (old('allocations') ?? 0) }}"
                                                 id="allocations" name="allocations" type="number"
                                                 class="form-control @error('allocations') is-invalid @enderror"
                                                 required="required">
@@ -321,7 +321,7 @@
                                 <div class="row">
                                     <div class="col-lg-6">
                                         <div class="form-group">
-                                            <input type="checkbox" value="1" id="oom_killer" name="oom_killer">
+                                            <input type="checkbox" value="1" id="oom_killer" name="oom_killer" @if ($product->oom_killer) checked @endif>
                                             <label for="oom_killer">
                                                 {{ __('OOM Killer') }}
                                                 <i data-toggle="popover"
@@ -426,27 +426,35 @@
                 closeOnSelect: false
             });
 
+            // Logic to select all items in a group when the group label is clicked
             $(document).on('click', '.select2-results__group', function(e) {
                 const nestLabel = $(this).text().trim();
                 const $select = $('#eggs');
                 const allOptions = $select.find('option');
 
+                // Find all options that belong to this group (optgroup)
                 const groupOptions = allOptions.filter(function() {
                     const $this = $(this);
                     const $group = $this.closest('optgroup');
                     return $group.length && $group.attr('label') === nestLabel;
                 });
 
-                const allSelected = groupOptions. length > 0 && groupOptions.length === groupOptions.filter(':selected').length;
+                // Check if all are already selected
+                const allSelected = groupOptions.length > 0 && groupOptions.length === groupOptions.filter(':selected').length;
 
+                // Toggle selection
                 groupOptions.prop('selected', !allSelected);
+
+                // Trigger change to update Select2 visuals
                 $select.trigger('change');
 
+                // Optional: Select2 usually closes on selection, we might want to keep it open or let it close.
+                // Preventing default keeps the dropdown open if necessary, but Select2 rebuilds DOM on change.
                 e.stopPropagation();
                 return false;
             });
 
-            document. getElementById('select-all-eggs').addEventListener('click', function(e) {
+            document.getElementById('select-all-eggs').addEventListener('click', function(e) {
                 e.preventDefault();
                 $('#eggs option').prop('selected', true);
                 $('#eggs').trigger('change');


### PR DESCRIPTION
This PR refactors the themes/default/views/admin/products/create.blade.php file to improve code maintainability and fixes usability issues with the Select2 component.

Key Changes:
Select2 Logic & UX:

Fixed the logic for selecting/deselecting all child items when clicking a parent category (Nest).
Added CSS to visually highlight parent categories on hover.
Fixed a bug where child elements remained highlighted incorrectly after moving the cursor.

Code Formatting:
Standardized indentation and alignment of HTML attributes across all form elements (name, cpu, memory, etc.).
Cleaned up spacing in step and value attributes.

Consistency:
Unified the layout of labels and popover icons for a cleaner UI structure.



Linked Issues 🔗

[Bulk selection by Category (Nest) and prevent dropdown collapse in Egg selector](https://github.com/Ctrlpanel-gg/panel/issues/1288)