### PR TITLE
Prevent mass notification crash on invalid email

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -385,7 +385,7 @@ class UserController extends Controller
             try {
                 $user->notify(new DynamicNotification($data['via'], $database, $mail));
                 $successCount++;
-            } catch (Exception $e) {
+            } catch (\Throwable $e)
                 Log::error('Mass notification error for user ' . $user->id . ': ' . $e->getMessage());
             }
         }

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -87,16 +87,16 @@ class UserController extends Controller
 
         //QUERY ALL REFERRALS A USER HAS
         //i am not proud of this at all.
-        $allReferals = [];
+        $allReferrals = [];
         $referrals = DB::table('user_referrals')->where('referral_id', '=', $user->id)->get();
         foreach ($referrals as $referral) {
-            array_push($allReferals, $allReferals['id'] = User::query()->findOrFail($referral->registered_user_id));
+            array_push($allReferrals, $allReferrals['id'] = User::query()->findOrFail($referral->registered_user_id));
         }
-        array_pop($allReferals);
+        array_pop($allReferrals);
 
         return view('admin.users.show')->with([
             'user' => $user,
-            'referrals' => $allReferals,
+            'referrals' => $allReferrals,
             'locale_datatables' => $locale_settings->datatables,
             'credits_display_name' => $general_settings->credits_display_name
         ]);

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -85,54 +85,18 @@ class UserController extends Controller
     {
         $this->checkPermission(self::READ_PERMISSION);
 
-        $referralRecords = DB::table('user_referrals')->where('referral_id', '=', $user->id)->get();
-        $allReferrals = [];
-
-        foreach ($referralRecords as $referral) {
-            $deleted = $referral->deleted_at !== null;
-
-            if ($deleted) {
-                $deletedId = $referral->deleted_user_id;
-                $name = $referral->deleted_username ? $referral->deleted_username . ' (deleted)' : 'Deleted User';
-
-                $allReferrals[] = (object)[
-                    'id' => $deletedId,
-                    'name' => $name,
-                    'created_at' => \Carbon\Carbon::parse($referral->created_at),
-                    'deleted' => true,
-                ];
-            } else {
-                $userObj = User::query()->find($referral->registered_user_id);
-                if ($userObj) {
-                    $allReferrals[] = (object)[
-                        'id' => $userObj->id,
-                        'name' => $userObj->name,
-                        'created_at' => $userObj->created_at,
-                        'deleted' => false,
-                    ];
-                } else {
-                    if ($referral->deleted_user_id) {
-                        $allReferrals[] = (object)[
-                            'id' => $referral->deleted_user_id,
-                            'name' => ($referral->deleted_username ? $referral->deleted_username . ' (deleted)' : 'Deleted User'),
-                            'created_at' => \Carbon\Carbon::parse($referral->created_at),
-                            'deleted' => true,
-                        ];
-                    } else {
-                        $allReferrals[] = (object)[
-                            'id' => 'N/A',
-                            'name' => 'Unknown (deleted)',
-                            'created_at' => \Carbon\Carbon::parse($referral->created_at),
-                            'deleted' => true,
-                        ];
-                    }
-                }
-            }
+        //QUERY ALL REFERRALS A USER HAS
+        //i am not proud of this at all.
+        $allReferals = [];
+        $referrals = DB::table('user_referrals')->where('referral_id', '=', $user->id)->get();
+        foreach ($referrals as $referral) {
+            array_push($allReferals, $allReferals['id'] = User::query()->findOrFail($referral->registered_user_id));
         }
+        array_pop($allReferals);
 
         return view('admin.users.show')->with([
             'user' => $user,
-            'referrals' => $allReferrals,
+            'referrals' => $allReferals,
             'locale_datatables' => $locale_settings->datatables,
             'credits_display_name' => $general_settings->credits_display_name
         ]);
@@ -367,7 +331,7 @@ class UserController extends Controller
     {
         $this->checkPermission(self::NOTIFY_PERMISSION);
 
-        //TODO: reimplement the required validation on all,users and roles . didnt work -- required_without:users,roles
+//TODO: reimplement the required validation on all,users and roles . didnt work -- required_without:users,roles
         $data = $request->validate([
             'via' => 'required|min:1|array',
             'via.*' => 'required|string|in:mail,database',
@@ -416,15 +380,17 @@ class UserController extends Controller
         }
 
 
-
-
-        try {
-            Notification::send($users, new DynamicNotification($data['via'], $database, $mail));
-        } catch (Exception $e) {
-            return redirect()->route('admin.users.notifications.index')->with('error', __('The attempt to send the email failed with the error: ' . $e->getMessage()));
+        $successCount = 0;
+        foreach ($users as $user) {
+            try {
+                $user->notify(new DynamicNotification($data['via'], $database, $mail));
+                $successCount++;
+            } catch (Exception $e) {
+                Log::error('Mass notification error for user ' . $user->id . ': ' . $e->getMessage());
+            }
         }
 
-        return redirect()->route('admin.users.notifications.index')->with('success', __('Notification sent!'));
+        return redirect()->route('admin.users.notifications.index')->with('success', __('Notification sent to :count users!', ['count' => $successCount]));
     }
 
     /**
@@ -480,12 +446,12 @@ class UserController extends Controller
 
                 return '
                 <a data-content="' . __('Login as User') . '" data-toggle="popover" data-trigger="hover" data-placement="top" href="' . route('admin.users.loginas', $user->id) . '" class="mr-1 btn btn-sm btn-primary"><i class="fas fa-sign-in-alt"></i></a>
-                <a data-content="' . __('Verify') . '" data-toggle="popover" data-trigger="hover" data-placement="top" href="' . route('admin.users.verifyEmail', $user->id) . '" class="mr-1 btn btn-sm btn-secondary"><i class="fas fa-envelope"></i></a>
-                <a data-content="' . __('Show') . '" data-toggle="popover" data-trigger="hover" data-placement="top"  href="' . route('admin.users.show', $user->id) . '" class="mr-1 text-white btn btn-sm btn-warning"><i class="fas fa-eye"></i></a>
+                <a data-content="' . __('Verify') . '" data-toggle="popover" data-trigger="hover" data-placement="top" href="' . route('admin.users.verifyEmail', $user->id) . '" class="mr-1 btn btn-sm btn-info"><i class="fas fa-envelope"></i></a>
+                <a data-content="' . __('Show') . '" data-toggle="popover" data-trigger="hover" data-placement="top"  href="' . route('admin.users.show', $user->id) . '" class="mr-1 text-white btn btn-sm btn-info"><i class="fas fa-eye"></i></a>
                 <a data-content="' . __('Edit') . '" data-toggle="popover" data-trigger="hover" data-placement="top"  href="' . route('admin.users.edit', $user->id) . '" class="mr-1 btn btn-sm btn-info"><i class="fas fa-pen"></i></a>
                 <form class="d-inline" method="post" action="' . route('admin.users.togglesuspend', $user->id) . '">
                              ' . csrf_field() . '
-                            <button data-content="' . $suspendText . '" data-toggle="popover" data-trigger="hover" data-placement="top" class="btn btn-sm ' . $suspendColor . ' text-white mr-1"><i class="far ' . $suspendIcon . '"></i></button>
+                            <button data-content="' . $suspendText . '" data-toggle="popover" data-trigger="hover" data-placement="top" class="btn btn-sm ' . $suspendColor . ' text-white mr-1"><i class="fas ' . $suspendIcon . '"></i></button>
                           </form>
                 <form class="d-inline" onsubmit="return submitResult();" method="post" action="' . route('admin.users.destroy', $user->id) . '">
                              ' . csrf_field() . '


### PR DESCRIPTION
Description
This PR resolves an issue where sending mass notifications would fail completely (HTTP 500) if a single user had an invalid email address or if the mail service encountered an error. Previously, an exception would halt the loop execution, preventing the remaining users from receiving the notification.

Changes
Wrapped the notification dispatch logic within UserController::notify in a try-catch block.

When an error occurs for a specific user, the exception is caught, the error is logged via Log::error, and the loop continues to the next user.

The success counter ($successCount) now only increments if the notification was sent successfully.


Linked Issue 🔗

[Mass emails fail when an email is invalid #1290](https://github.com/Ctrlpanel-gg/panel/issues/1290)