### PR TITLE
Add ability to revoke server cancellation

### DIFF
--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -388,6 +388,22 @@ class ServerController extends Controller
         }
     }
 
+    public function uncancel(Server $server): RedirectResponse
+    {
+        if ($server->user_id !== Auth::id()) {
+            return back()->with('error', __('This is not your Server!'));
+        }
+
+        try {
+            $server->update(['canceled' => null]);
+            return redirect()->route('servers.index')
+                ->with('success', __('Server cancellation has been revoked'));
+        } catch (Exception $e) {
+            return redirect()->route('servers.index')
+                ->with('error', __('Server cancellation revoke failed: ') . $e->getMessage());
+        }
+    }
+
     public function show(Server $server): \Illuminate\View\View
     {
         if ($server->user_id !== Auth::id()) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -65,6 +65,7 @@ Route::middleware(['auth', 'checkSuspended'])->group(function () {
     Route::get('notifications/readAll', [NotificationController::class, 'readAll'])->name('notifications.readAll');
     Route::resource('notifications', NotificationController::class);
     Route::patch('/servers/cancel/{server}', [ServerController::class, 'cancel'])->name('servers.cancel');
+    Route::patch('/servers/uncancel/{server}', [ServerController::class, 'uncancel'])->name('servers.uncancel');
     Route::post('/servers/validateDeploymentVariables', [ServerController::class, 'validateDeploymentVariables'])->name('servers.validateDeploymentVariables');
     Route::patch('/servers/{server}/billing_priority', [ServerController::class, 'updateBillingPriority'])->name('servers.updateBillingPriority');
     Route::delete('/servers/{server}', [ServerController::class, 'destroy'])->name('servers.destroy');

--- a/themes/default/views/servers/index.blade.php
+++ b/themes/default/views/servers/index.blade.php
@@ -199,10 +199,15 @@
                                 <i class="mx-2 fas fa-cog"></i>
                             </a>
                             
-                            @if ($server->canceled)
+                            @if ($server->canceled && !$server->suspended)
                                 <button onclick="handleServerUncancel('{{ $server->id }}');" target="__blank"
                                     class="text-center btn btn-success"
                                     data-toggle="tooltip" data-placement="bottom" title="{{ __('Restore Server') }}">
+                                    <i class="mx-2 fas fa-check"></i>
+                                </button>
+                            @elseif ($server->canceled && $server->suspended)
+                                <button class="text-center btn btn-success" disabled
+                                    data-toggle="tooltip" data-placement="bottom" title="{{ __('Server is suspended and cannot be fully restored.') }}">
                                     <i class="mx-2 fas fa-check"></i>
                                 </button>
                             @else

--- a/themes/default/views/servers/index.blade.php
+++ b/themes/default/views/servers/index.blade.php
@@ -206,10 +206,11 @@
                                     <i class="mx-2 fas fa-check"></i>
                                 </button>
                             @elseif ($server->canceled && $server->suspended)
-                                <button class="text-center btn btn-success" disabled
-                                    data-toggle="tooltip" data-placement="bottom" title="{{ __('Server is suspended and cannot be fully restored.') }}">
-                                    <i class="mx-2 fas fa-check"></i>
-                                </button>
+                                <span data-toggle="tooltip" data-placement="bottom" title="{{ __('Server is suspended and cannot be fully restored.') }}">
+                                    <button class="text-center btn btn-success" disabled>
+                                        <i class="mx-2 fas fa-check"></i>
+                                    </button>
+                                </span>
                             @else
                                 <button onclick="handleServerCancel('{{ $server->id }}');" target="__blank"
                                     class="text-center btn btn-warning"

--- a/themes/default/views/servers/index.blade.php
+++ b/themes/default/views/servers/index.blade.php
@@ -287,7 +287,10 @@
                         headers: {
                             'X-CSRF-TOKEN': '{{ csrf_token() }}'
                         }
-                    }).then(() => {
+                    }).then((response) => {
+                        if (!response.ok) {
+                            throw new Error('Failed to restore server');
+                        }
                         window.location.reload();
                     }).catch((error) => {
                         Swal.fire({

--- a/themes/default/views/servers/index.blade.php
+++ b/themes/default/views/servers/index.blade.php
@@ -1,7 +1,6 @@
 @extends('layouts.main')
 
 @section('content')
-    <!-- CONTENT HEADER -->
     <section class="content-header">
         <div class="container-fluid">
             <div class="mb-2 row">
@@ -19,13 +18,9 @@
             </div>
         </div>
     </section>
-    <!-- END CONTENT HEADER -->
-
-    <!-- MAIN CONTENT -->
     <section class="content">
         <div class="container-fluid">
 
-            <!-- CUSTOM CONTENT -->
             <div class="mb-3 d-flex justify-content-md-start justify-content-center ">
                 <a @if (Auth::user()->Servers->count() >= Auth::user()->server_limit) disabled="disabled" title="Server limit reached!" @endif
                    @cannot("user.server.create") disabled="disabled" title="No Permission!" @endcannot
@@ -177,7 +172,7 @@
                                             <i data-toggle="popover" data-trigger="hover"
                                                data-content="{{ __('Your') ." " . $credits_display_name . " ". __('are reduced') ." ". $server->product->billing_period . ". " . __("This however calculates to ") . Currency::formatForDisplay($server->product->getMonthlyPrice()) . " ". $credits_display_name . " ". __('per Month')}}"
                                                class="fas fa-info-circle"></i>
-                                            </div>
+                                        </div>
                                         <span>
                                             {{ $server->product->display_price }}
                                         </span>
@@ -194,16 +189,26 @@
                                 <i class="mx-2 fas fa-tools"></i>
                             </a>
                             <a href="{{ route('servers.show', ['server' => $server->id])}}"
-                            	class="mr-3 text-center btn btn-info"
-                            	data-toggle="tooltip" data-placement="bottom" title="{{ __('Server Settings') }}">
+                                class="mr-3 text-center btn btn-info"
+                                data-toggle="tooltip" data-placement="bottom" title="{{ __('Server Settings') }}">
                                 <i class="mx-2 fas fa-cog"></i>
                             </a>
-                            <button onclick="handleServerCancel('{{ $server->id }}');" target="__blank"
-                                class="text-center btn btn-warning"
-                                {{ $server->suspended || $server->canceled ? "disabled" : "" }}
-                                data-toggle="tooltip" data-placement="bottom" title="{{ __('Cancel Server') }}">
-                                <i class="mx-2 fas fa-ban"></i>
-                            </button>
+                            
+                            @if ($server->canceled)
+                                <button onclick="handleServerUncancel('{{ $server->id }}');" target="__blank"
+                                    class="text-center btn btn-success"
+                                    data-toggle="tooltip" data-placement="bottom" title="{{ __('Restore Server') }}">
+                                    <i class="mx-2 fas fa-check"></i>
+                                </button>
+                            @else
+                                <button onclick="handleServerCancel('{{ $server->id }}');" target="__blank"
+                                    class="text-center btn btn-warning"
+                                    {{ $server->suspended ? "disabled" : "" }}
+                                    data-toggle="tooltip" data-placement="bottom" title="{{ __('Cancel Server') }}">
+                                    <i class="mx-2 fas fa-ban"></i>
+                                </button>
+                            @endif
+
                             <button onclick="handleServerDelete('{{ $server->id }}');" target="__blank"
                                 class="float-right mr-2 text-center btn btn-danger"
                                 data-toggle="tooltip" data-placement="bottom" title="{{ __('Delete Server') }}">
@@ -214,11 +219,8 @@
                  @endif
                 @endforeach
             </div>
-            <!-- END CUSTOM CONTENT -->
         </div>
     </section>
-    <!-- END CONTENT -->
-
     <script>
         const handleServerCancel = (serverId) => {
             // Handle server cancel with sweetalert
@@ -235,6 +237,39 @@
                 if (result.value) {
                     // Delete server
                     fetch("{{ route('servers.cancel', '') }}" + '/' + serverId, {
+                        method: 'PATCH',
+                        headers: {
+                            'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                        }
+                    }).then(() => {
+                        window.location.reload();
+                    }).catch((error) => {
+                        Swal.fire({
+                            title: "{{ __('Error') }}",
+                            text: "{{ __('Something went wrong, please try again later.') }}",
+                            icon: 'error',
+                            confirmButtonColor: '#d9534f',
+                        })
+                    })
+                    return
+                }
+            })
+        }
+
+        const handleServerUncancel = (serverId) => {
+            // Handle server uncancel with sweetalert
+            Swal.fire({
+                title: "{{ __('Restore Server?') }}",
+                text: "{{ __('This will restore your server and cancel the cancellation. Your server will no longer be suspended at the end of the billing period.') }}",
+                icon: 'info',
+                confirmButtonColor: '#28a745',
+                showCancelButton: true,
+                confirmButtonText: "{{ __('Yes, restore it!') }}",
+                cancelButtonText: "{{ __('No, abort!') }}",
+                reverseButtons: true
+            }).then((result) => {
+                if (result.value) {
+                    fetch("{{ route('servers.uncancel', '') }}" + '/' + serverId, {
                         method: 'PATCH',
                         headers: {
                             'X-CSRF-TOKEN': '{{ csrf_token() }}'

--- a/themes/default/views/servers/index.blade.php
+++ b/themes/default/views/servers/index.blade.php
@@ -1,6 +1,7 @@
 @extends('layouts.main')
 
 @section('content')
+    <!-- CONTENT HEADER -->
     <section class="content-header">
         <div class="container-fluid">
             <div class="mb-2 row">
@@ -18,9 +19,13 @@
             </div>
         </div>
     </section>
+    <!-- END CONTENT HEADER -->
+
+    <!-- MAIN CONTENT -->
     <section class="content">
         <div class="container-fluid">
 
+            <!-- CUSTOM CONTENT -->
             <div class="mb-3 d-flex justify-content-md-start justify-content-center ">
                 <a @if (Auth::user()->Servers->count() >= Auth::user()->server_limit) disabled="disabled" title="Server limit reached!" @endif
                    @cannot("user.server.create") disabled="disabled" title="No Permission!" @endcannot
@@ -219,8 +224,11 @@
                  @endif
                 @endforeach
             </div>
+            <!-- END CUSTOM CONTENT -->
         </div>
     </section>
+    <!-- END CONTENT -->
+     
     <script>
         const handleServerCancel = (serverId) => {
             // Handle server cancel with sweetalert


### PR DESCRIPTION
## Problem
Currently, once a server is canceled, the Cancel button becomes inactive and users cannot revert the cancellation. This prevents restoring a server if the cancellation was accidental.

## Solution
- Introduce a PATCH route to uncancel a server
- Add uncancel() method in ServerController to restore canceled servers
- Update the server index Blade template to show conditional Cancel (yellow) or Restore (green) buttons
- Add SweetAlert2 confirmation dialog for uncancel action
- Ensure users can restore canceled servers before the billing period ends

## Changes
- routes/web.php
- app/Http/Controllers/ServerController.php
- themes/default/views/servers/index.blade.php

## Features
- Active servers show a yellow Cancel button
- Canceled servers show a green Restore button
- Users receive proper feedback on server restoration