### PR TITLE
fix: added missing credits in make user command

### DIFF
--- a/app/Console/Commands/MakeUserCommand.php
+++ b/app/Console/Commands/MakeUserCommand.php
@@ -88,6 +88,7 @@ class MakeUserCommand extends Command
             'email' => $response['email'],
             'password' => Hash::make($password),
             'referral_code' => $this->createReferralCode(),
+            'credits' => config('SETTINGS::USER:INITIAL_CREDITS', 150),
             'pterodactyl_id' => $response['id'],
         ]);
 


### PR DESCRIPTION
# Problem
The command make:user (php artisan make:user) don't work.

# Solution
Add the credits in the make user.

# Changes
app/Console/Commands/MakeUserCommand.php

# Console Output

Before the Change:
```
➜ development git:(main) ✗ docker compose exec ctrlpanel_development php artisan make:user 

 Please specify your Pterodactyl ID.:
 > 2

 password:
 > 

   Illuminate\Database\QueryException 

  SQLSTATE[HY000]: General error: 1364 Field 'credits' doesn't have a default value (Connection: mysql, SQL: insert into `users` (`name`, `email`, `password`, `referral_code`, `pterodactyl_id`, `updated_at`, `created_at`) values (Keks, admin@example.com, $2y$10$P.guaep0m..., OP0mXhoo, 1, 2026-03-12 11:09:59, 2026-03-12 11:09:59))

  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:825
    821▕                     $this->getName(), $query, $this->prepareBindings($bindings), $e
    822▕                 );
    823▕             }
    824▕ 
  ➜ 825▕             throw new QueryException(
    826▕                 $this->getName(), $query, $this->prepareBindings($bindings), $e
    827▕             );
    828▕         }
    829▕     }

      +17 vendor frames 

  18  app/Console/Commands/MakeUserCommand.php:86
      Illuminate\Database\Eloquent\Model::__callStatic("create")
      +12 vendor frames 

  31  artisan:35
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))


```

After the Change:
```
➜  development git:(main) ✗ docker compose exec ctrlpanel_development php artisan make:user 

 Please specify your Pterodactyl ID.:
 > 2

 password:
 > 

+---------------+-------------------+
| Field         | Value             |
+---------------+-------------------+
| ID            | 3                 |
| Email         | admin@example.com |
| Username      | Admin             |
| Ptero-ID      | 2                 |
| Referral code | tMP8fYIi          |
+---------------+-------------------+
```