### PR TITLE
feat(provisioning): robust server creation + reconciliation safeguards

### DIFF
--- a/app/Classes/PterodactylClient.php
+++ b/app/Classes/PterodactylClient.php
@@ -302,6 +302,22 @@ class PterodactylClient
         }
     }
 
+    /**
+     * Get a server by external_id on Pterodactyl.
+     *
+     * @param string $externalId
+     * @return \Illuminate\Http\Client\Response
+     * @throws Exception
+     */
+    public function getServerByExternalId(string $externalId)
+    {
+        try {
+            return $this->application->get("application/servers/external/{$externalId}");
+        } catch (Exception $e) {
+            throw self::getException('Failed to get server by external_id from pterodactyl - ' . $e->getMessage());
+        }
+    }
+
     public function suspendServer(Server $server)
     {
         try {
@@ -407,7 +423,7 @@ class PterodactylClient
      * @param  Server  $server
      * @param  Product  $product
      * @return Response
-     * 
+     *
      * @deprecated Use updateServerBuild instead.
      */
     public function updateServer(Server $server, Product $product)
@@ -434,7 +450,7 @@ class PterodactylClient
      *
      * @param  Server  $server
      * @return Response
-     * 
+     *
      * @throws Exception
      */
     public function updateServerBuild(string $pterodactylId, int $pterodactylAllocation, Product $product)
@@ -487,7 +503,7 @@ class PterodactylClient
      * @param  Server  $server
      * @param  array  $data
      * @return Response
-     * 
+     *
      * @throws HttpException
      * @throws Exception
      */

--- a/app/Http/Controllers/Api/ServerController.php
+++ b/app/Http/Controllers/Api/ServerController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Api;
 
 use App\Classes\PterodactylClient;
-use App\Events\ServerCreatedEvent;
 use App\Events\ServerDeletedEvent;
 use App\Models\Product;
 use App\Models\User;

--- a/app/Http/Controllers/Api/ServerController.php
+++ b/app/Http/Controllers/Api/ServerController.php
@@ -68,7 +68,7 @@ class ServerController extends Controller
      * @param  Request  $request
      * @param  string  $serverId
      * @return ServerResource
-     * 
+     *
      * @throws ModelNotFoundException
      */
     public function show(Request $request, string $serverId)
@@ -86,7 +86,7 @@ class ServerController extends Controller
      *
      * @param  Request  $request
      * @return ServerResource
-     * 
+     *
      * @throws ValidationException
      */
     public function store(CreateServerRequest $request)
@@ -98,10 +98,6 @@ class ServerController extends Controller
 
         try {
             $server = $this->serverCreationService->handle($user, $product, $data);
-
-            $user->decrement("credits", $product->price);
-
-            event(new ServerCreatedEvent($user, $server));
 
             return ServerResource::make($server->fresh());
         } catch (Exception $e) {
@@ -117,7 +113,7 @@ class ServerController extends Controller
      * @param UpdateServerRequest $request
      * @param Server $server
      * @return ServerResource
-     * 
+     *
      * @throws ModelNotFoundException
      * @throws Exception
      */
@@ -157,7 +153,7 @@ class ServerController extends Controller
      * @param  UpdateServerBuildRequest  $request
      * @param  Server  $server
      * @return ServerResource|JsonResponse
-     * 
+     *
      * @throws ModelNotFoundException
      */
     public function updateBuild(UpdateServerBuildRequest $request, Server $server)
@@ -182,7 +178,7 @@ class ServerController extends Controller
      * @param  DeleteServerRequest  $request
      * @param  Server  $server
      * @return \Illuminate\Http\Response
-     * 
+     *
      * @throws ModelNotFoundException
      */
     public function destroy(DeleteServerRequest $request, Server $server)
@@ -214,7 +210,7 @@ class ServerController extends Controller
      * @param  SuspendServerRequest  $request
      * @param  Server  $server
      * @return ServerResource|JsonResponse
-     * 
+     *
      * @throws ModelNotFoundException
      */
     public function suspend(SuspendServerRequest $request, Server $server)
@@ -244,7 +240,7 @@ class ServerController extends Controller
      * @param  UnsuspendServerRequest  $request
      * @param  Server  $server
      * @return ServerResource|JsonResponse
-     * 
+     *
      * @throws ModelNotFoundException
      */
     public function unSuspend(UnsuspendServerRequest $request, Server $server)

--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -291,71 +291,22 @@ class ServerController extends Controller
         }
     }
 
+    /**
+     * @deprecated Once everyone is migrated to ServerCreationService.
+     */
     private function createServer(Request $request): ?Server
     {
-        $product = Product::findOrFail($request->input('product'));
-        $egg = $product->eggs()->findOrFail($request->input('egg'));
-        $node = $this->findAvailableNode($request->input('location'), $product);
-
-        if (!$node) return null;
-
-        $server = $request->user()->servers()->create([
-            'name' => $request->input('name'),
-            'product_id' => $product->id,
-            'last_billed' => Carbon::now(),
-            'billing_priority' => $request->input('billing_priority', $product->default_billing_priority),
-        ]);
-
-        $allocationId = $this->pterodactyl->getFreeAllocationId($node);
-        if (!$allocationId) {
-            Log::error('No AllocationID found.', [
-                'server_id' => $server->id,
-                'node_id' => $node->id,
-            ]);
-            $server->delete();
-            return null;
-        }
-
-        $response = $this->pterodactyl->createServer($server, $egg, $allocationId, $request->input('egg_variables'));
-        if ($response->failed()) {
-            Log::error('Failed to create server on Pterodactyl', [
-                'server_id' => $server->id,
-                'status' => $response->status(),
-                'error' => $response->json()
-            ]);
-            $server->delete();
-            return null;
-        }
-
-        $serverAttributes = $response->json()['attributes'];
-        $server->update([
-            'pterodactyl_id' => $serverAttributes['id'],
-            'identifier' => $serverAttributes['identifier']
-        ]);
-
-        return $server;
+        // Legacy path; use ServerCreationService::handle() instead.
+        throw new \BadMethodCallException('createServer() is deprecated. Use ServerCreationService::handle().');
     }
 
+    /**
+     * @deprecated Once everyone is migrated to ServerCreationService.
+     */
     private function handlePostCreation(User $user, Server $server): void
     {
-        logger('Product Price: ' . $server->product->price);
-
-        $user->decrement('credits', $server->product->price);
-        Cache::forget('user_credits_left:' . $user->id);
-
-        try {
-            if ($this->discordSettings->role_for_active_clients &&
-                $user->discordUser &&
-                $user->servers->count() >= 1
-            ) {
-                $user->discordUser->addOrRemoveRole(
-                    'add',
-                    $this->discordSettings->role_id_for_active_clients
-                );
-            }
-        } catch (Exception $e) {
-            Log::debug('Discord role update failed: ' . $e->getMessage());
-        }
+        // Legacy path; use PostServerCreationJob for idempotent async processing.
+        throw new \BadMethodCallException('handlePostCreation() is deprecated. Use PostServerCreationJob instead.');
     }
 
     public function destroy(Server $server): RedirectResponse

--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -14,6 +14,7 @@ use App\Settings\DiscordSettings;
 use Carbon\Carbon;
 use App\Settings\UserSettings;
 use App\Settings\ServerSettings;
+use App\Services\ServerCreationService;
 use App\Settings\PterodactylSettings;
 use App\Classes\PterodactylClient;
 use App\Enums\BillingPriority;
@@ -51,13 +52,15 @@ class ServerController extends Controller
     private ServerSettings $serverSettings;
     private UserSettings $userSettings;
     private DiscordSettings $discordSettings;
+    private ServerCreationService $serverCreationService;
 
     public function __construct(
         PterodactylSettings $pteroSettings,
         GeneralSettings $generalSettings,
         ServerSettings $serverSettings,
         UserSettings $userSettings,
-        DiscordSettings $discordSettings
+        DiscordSettings $discordSettings,
+        ServerCreationService $serverCreationService
     ) {
         $this->pteroSettings = $pteroSettings;
         $this->pterodactyl = new PterodactylClient($pteroSettings);
@@ -65,6 +68,7 @@ class ServerController extends Controller
         $this->serverSettings = $serverSettings;
         $this->userSettings = $userSettings;
         $this->discordSettings = $discordSettings;
+        $this->serverCreationService = $serverCreationService;
     }
 
     public function index(): \Illuminate\View\View
@@ -120,7 +124,10 @@ class ServerController extends Controller
         Cache::put($lockKey, true, 5);
 
         $validationResult = $this->validateServerCreation($request);
-        if ($validationResult) return $validationResult;
+        if ($validationResult) {
+            Cache::forget($lockKey);
+            return $validationResult;
+        }
 
         $request->validate([
             'name' => 'required|max:191',
@@ -131,17 +138,33 @@ class ServerController extends Controller
             'billing_priority' => ['nullable', new Enum(BillingPriority::class)],
         ]);
 
-        $server = $this->createServer($request);
+        try {
+            $user = $request->user();
+            $product = Product::findOrFail($request->input('product'));
 
-        if (!$server) {
+            $server = $this->serverCreationService->handle($user, $product, [
+                'name' => $request->input('name'),
+                'egg_id' => $request->input('egg'),
+                'location_id' => $request->input('location'),
+                'billing_priority' => $request->input('billing_priority', $product->default_billing_priority),
+                'egg_variables' => $request->input('egg_variables'),
+            ]);
+
+            Cache::forget($lockKey);
+
+            if (!$server) {
+                return redirect()->route('servers.index')
+                    ->with('error', __('Server creation failed'));
+            }
+
             return redirect()->route('servers.index')
-                ->with('error', __('Server creation failed'));
+                ->with('success', __('Server created'));
+        } catch (Exception $e) {
+            Cache::forget($lockKey);
+
+            return redirect()->route('servers.index')
+                ->with('error', $e->getMessage());
         }
-
-        $this->handlePostCreation($request->user(), $server);
-
-        return redirect()->route('servers.index')
-            ->with('success', __('Server created'));
     }
 
     private function validateServerCreation(Request $request): ?RedirectResponse

--- a/app/Http/Resources/ServerResource.php
+++ b/app/Http/Resources/ServerResource.php
@@ -28,6 +28,7 @@ class ServerResource extends JsonResource
             'created_at' => $this->created_at->toDateTimeString(),
             'updated_at' => $this->updated_at->toDateTimeString(),
             'last_billed' => $this->last_billed->toDateTimeString(),
+            'status' => $this->status,
             'product_count' => $this->whenCounted('product'),
             'product_exists' => $this->whenExistsLoaded('product'),
             'product' => ProductResource::make($this->whenLoaded('product')),

--- a/app/Jobs/PostServerCreationJob.php
+++ b/app/Jobs/PostServerCreationJob.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Events\ServerCreatedEvent;
+use App\Models\Server;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class PostServerCreationJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public string $serverId;
+
+    public function __construct(string $serverId)
+    {
+        $this->serverId = $serverId;
+        $this->queue = 'default';
+    }
+
+    public function handle(): void
+    {
+        $server = Server::with('user')->find($this->serverId);
+
+        if (!$server || $server->status !== Server::STATUS_ACTIVE) {
+            return;
+        }
+
+        if (!$server->user) {
+            return;
+        }
+
+        event(new ServerCreatedEvent($server->user, $server));
+    }
+}

--- a/app/Jobs/ReconcileServerCreationJob.php
+++ b/app/Jobs/ReconcileServerCreationJob.php
@@ -129,15 +129,23 @@ class ReconcileServerCreationJob implements ShouldQueue
             }
 
             if ($response->status() === 404) {
-                if ($server->status !== Server::STATUS_FAILED) {
+                $updated = Server::where('id', $server->id)
+                    ->where('status', '!=', Server::STATUS_FAILED)
+                    ->update(['status' => Server::STATUS_FAILED]);
+
+                if ($updated === 1) {
                     $creditService->refund($server->user, $this->chargedPrice);
-                    $server->update(['status' => Server::STATUS_FAILED]);
+                    Log::critical('ReconcileServerCreationJob failed after retries with remote 404; refunded credits', [
+                        'server_id' => $this->serverId,
+                        'amount' => $this->chargedPrice,
+                        'error' => $exception->getMessage(),
+                    ]);
+                } else {
+                    Log::info('ReconcileServerCreationJob failed after retries with remote 404; no refund needed because status already failed', [
+                        'server_id' => $this->serverId,
+                    ]);
                 }
 
-                Log::critical('ReconcileServerCreationJob failed after retries with remote 404; refunded credits', [
-                    'server_id' => $this->serverId,
-                    'error' => $exception->getMessage(),
-                ]);
                 return;
             }
 

--- a/app/Jobs/ReconcileServerCreationJob.php
+++ b/app/Jobs/ReconcileServerCreationJob.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Classes\PterodactylClient;
+use App\Models\Server;
+use App\Services\CreditService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class ReconcileServerCreationJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 5;
+    public string $serverId;
+    public float $chargedPrice;
+
+    public function __construct(string $serverId, float $chargedPrice)
+    {
+        $this->serverId = $serverId;
+        $this->chargedPrice = $chargedPrice;
+        $this->queue = 'default';
+    }
+
+    public function handle(PterodactylClient $pterodactylClient, CreditService $creditService): void
+    {
+        $server = Server::find($this->serverId);
+
+        if (!$server) {
+            return;
+        }
+
+        if ($server->status === Server::STATUS_FAILED) {
+            return;
+        }
+
+        if ($server->status === Server::STATUS_ACTIVE && $server->pterodactyl_id) {
+            return;
+        }
+
+        if ($server->pterodactyl_id) {
+            $server->update(['status' => Server::STATUS_ACTIVE]);
+            dispatch(new PostServerCreationJob($server->id));
+            return;
+        }
+
+        try {
+            $response = $pterodactylClient->getServerByExternalId($server->id);
+        } catch (\Exception $e) {
+            Log::warning('ReconcileServerCreationJob: pterodactyl API request failed', [
+                'server_id' => $server->id,
+                'error' => $e->getMessage(),
+            ]);
+            throw $e;
+        }
+
+        if ($response->successful()) {
+            $attributes = $response->json()['attributes'] ?? null;
+
+            if (!$attributes || !isset($attributes['id']) || !isset($attributes['identifier'])) {
+                throw new \Exception('ReconcileServerCreationJob: invalid pterodactyl server payload');
+            }
+
+            $server->update([
+                'pterodactyl_id' => $attributes['id'],
+                'identifier' => $attributes['identifier'],
+                'status' => Server::STATUS_ACTIVE,
+            ]);
+
+            dispatch(new PostServerCreationJob($server->id));
+
+            return;
+        }
+
+        if ($response->status() === 404) {
+            // Avoid double refunds if already failed or already handled by another instance.
+            if ($server->status !== Server::STATUS_FAILED) {
+                $creditService->refund($server->user, $this->chargedPrice);
+                $server->update(['status' => Server::STATUS_FAILED]);
+            }
+            return;
+        }
+
+        throw new \Exception('ReconcileServerCreationJob: pterodactyl API returned non-404 failure status ' . $response->status());
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        $server = Server::find($this->serverId);
+
+        if (!$server || $server->status === Server::STATUS_ACTIVE) {
+            return;
+        }
+
+        $server->update(['status' => Server::STATUS_FAILED]);
+
+        Log::critical('ReconcileServerCreationJob failed after maximum retries', [
+            'server_id' => $this->serverId,
+            'error' => $exception->getMessage(),
+        ]);
+    }
+}

--- a/app/Jobs/ReconcileServerCreationJob.php
+++ b/app/Jobs/ReconcileServerCreationJob.php
@@ -18,9 +18,9 @@ class ReconcileServerCreationJob implements ShouldQueue
 
     public int $tries = 5;
     public string $serverId;
-    public float $chargedPrice;
+    public int $chargedPrice;
 
-    public function __construct(string $serverId, float $chargedPrice)
+    public function __construct(string $serverId, int $chargedPrice)
     {
         $this->serverId = $serverId;
         $this->chargedPrice = $chargedPrice;
@@ -78,11 +78,19 @@ class ReconcileServerCreationJob implements ShouldQueue
         }
 
         if ($response->status() === 404) {
-            // Avoid double refunds if already failed or already handled by another instance.
-            if ($server->status !== Server::STATUS_FAILED) {
+            // Atomic transition to FAILED to avoid double refunds in concurrent workers.
+            $updated = Server::where('id', $server->id)
+                ->where('status', '!=', Server::STATUS_FAILED)
+                ->update(['status' => Server::STATUS_FAILED]);
+
+            if ($updated === 1) {
                 $creditService->refund($server->user, $this->chargedPrice);
-                $server->update(['status' => Server::STATUS_FAILED]);
+                Log::info('ReconcileServerCreationJob: refunded credits on confirmed 404', [
+                    'server_id' => $server->id,
+                    'amount' => $this->chargedPrice,
+                ]);
             }
+
             return;
         }
 
@@ -97,11 +105,54 @@ class ReconcileServerCreationJob implements ShouldQueue
             return;
         }
 
-        $server->update(['status' => Server::STATUS_FAILED]);
+        $pterodactylClient = app(PterodactylClient::class);
+        $creditService = app(CreditService::class);
 
-        Log::critical('ReconcileServerCreationJob failed after maximum retries', [
-            'server_id' => $this->serverId,
-            'error' => $exception->getMessage(),
-        ]);
+        try {
+            $response = $pterodactylClient->getServerByExternalId($server->id);
+            if ($response->successful()) {
+                $attributes = $response->json()['attributes'] ?? null;
+                if ($attributes && isset($attributes['id']) && isset($attributes['identifier'])) {
+                    $server->update([
+                        'pterodactyl_id' => $attributes['id'],
+                        'identifier' => $attributes['identifier'],
+                        'status' => Server::STATUS_ACTIVE,
+                    ]);
+                    dispatch(new PostServerCreationJob($server->id));
+
+                    Log::critical('ReconcileServerCreationJob failed after retries but remote server found; marked active', [
+                        'server_id' => $this->serverId,
+                        'error' => $exception->getMessage(),
+                    ]);
+                    return;
+                }
+            }
+
+            if ($response->status() === 404) {
+                if ($server->status !== Server::STATUS_FAILED) {
+                    $creditService->refund($server->user, $this->chargedPrice);
+                    $server->update(['status' => Server::STATUS_FAILED]);
+                }
+
+                Log::critical('ReconcileServerCreationJob failed after retries with remote 404; refunded credits', [
+                    'server_id' => $this->serverId,
+                    'error' => $exception->getMessage(),
+                ]);
+                return;
+            }
+
+            $server->update(['status' => Server::STATUS_PENDING_RECONCILIATION]);
+            Log::critical('ReconcileServerCreationJob failed after maximum retries; remote state unknown, keeping pending_reconciliation', [
+                'server_id' => $this->serverId,
+                'error' => $exception->getMessage(),
+            ]);
+        } catch (\Exception $e) {
+            // If remote check also fails, preserve pending state and log.
+            $server->update(['status' => Server::STATUS_PENDING_RECONCILIATION]);
+            Log::critical('ReconcileServerCreationJob failed and remote check failed; keeping pending_reconciliation', [
+                'server_id' => $this->serverId,
+                'exception' => $e->getMessage(),
+            ]);
+        }
     }
 }

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -52,6 +52,11 @@ class Server extends Model
     /**
      * @var string[]
      */
+    public const STATUS_PROVISIONING = 'provisioning';
+    public const STATUS_ACTIVE = 'active';
+    public const STATUS_FAILED = 'failed';
+    public const STATUS_PENDING_RECONCILIATION = 'pending_reconciliation';
+
     protected $fillable = [
         "name",
         "description",
@@ -63,7 +68,8 @@ class Server extends Model
         "pterodactyl_id",
         "user_id",
         "last_billed",
-        "canceled"
+        "canceled",
+        "status"
     ];
 
     /**

--- a/app/Services/CreditService.php
+++ b/app/Services/CreditService.php
@@ -7,7 +7,8 @@ use Illuminate\Support\Facades\Cache;
 
 class CreditService
 {
-    public function reserve(User $user, float $amount): void
+
+    public function reserve(User $user, int $amount): void
     {
         $reserved = User::where('id', $user->id)
             ->where('credits', '>=', $amount)
@@ -21,7 +22,7 @@ class CreditService
         Cache::forget('user_credits_left:' . $user->id);
     }
 
-    public function refund(User $user, float $amount): void
+    public function refund(User $user, int $amount): void
     {
         User::where('id', $user->id)->increment('credits', $amount);
 

--- a/app/Services/CreditService.php
+++ b/app/Services/CreditService.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+
+class CreditService
+{
+    public function reserve(User $user, float $amount): void
+    {
+        $reserved = User::where('id', $user->id)
+            ->where('credits', '>=', $amount)
+            ->decrement('credits', $amount);
+
+        if ($reserved === 0) {
+            // Either not enough credits or another concurrent request updated this user first.
+            throw new \Exception('Unable to reserve credits: either insufficient balance or concurrent provisioning in progress. Please retry.');
+        }
+
+        Cache::forget('user_credits_left:' . $user->id);
+    }
+
+    public function refund(User $user, float $amount): void
+    {
+        User::where('id', $user->id)->increment('credits', $amount);
+
+        Cache::forget('user_credits_left:' . $user->id);
+    }
+}

--- a/app/Services/ServerCreationService.php
+++ b/app/Services/ServerCreationService.php
@@ -56,8 +56,10 @@ class ServerCreationService
         $lockKey = "server_provisioning_user_{$user->id}";
         $lock = Cache::lock($lockKey, 30);
 
-        if (!$lock->block(10)) {
-            throw new \Exception('Another provisioning request is in progress for this user.');
+        try {
+            $lock->block(10);
+        } catch (\Illuminate\Contracts\Cache\LockTimeoutException $exception) {
+            throw new \Exception('Another provisioning request is in progress for this user. Please try again in a few seconds.');
         }
 
         $server = null;
@@ -256,8 +258,14 @@ class ServerCreationService
             }
 
             if ($remoteResponse->status() === 404) {
-                $this->refundCredits($user, $chargedPrice);
-                $server->update(['status' => Server::STATUS_FAILED]);
+                // Atomic status transition to avoid double refund when update fails.
+                $updated = Server::where('id', $server->id)
+                    ->where('status', '!=', Server::STATUS_FAILED)
+                    ->update(['status' => Server::STATUS_FAILED]);
+
+                if ($updated === 1) {
+                    $this->refundCredits($user, $chargedPrice);
+                }
 
                 return $server;
             }

--- a/app/Services/ServerCreationService.php
+++ b/app/Services/ServerCreationService.php
@@ -51,7 +51,7 @@ class ServerCreationService
      */
     public function handle(User $user, Product $product, mixed $data): Server
     {
-        $egg = $product->eggs->firstWhere('id', $data['egg_id']);
+        $egg = null;
 
         $lockKey = "server_provisioning_user_{$user->id}";
         $lock = Cache::lock($lockKey, 30);
@@ -66,9 +66,15 @@ class ServerCreationService
         try {
             $validatedData = $this->validateAndPrepare($user, $product, $data);
 
-            DB::transaction(function () use ($user, $product, $validatedData, $data, &$server, &$creditsReserved) {
-                $this->reserveCredits($user, $product->price);
-                $creditsReserved = true;
+            $egg = $product->eggs()->find($data['egg_id']);
+            if (!$egg) {
+                throw new \Exception('Egg not attached to this product.');
+            }
+
+            $credits = (int) round($product->price);
+
+            DB::transaction(function () use ($user, $product, $credits, $validatedData, $data, &$server) {
+                $this->reserveCredits($user, $credits);
 
                 $server = Server::create([
                     'name' => $data['name'],
@@ -81,22 +87,36 @@ class ServerCreationService
                 ]);
             });
 
+            // Only mark credits as reserved after the transaction has committed.
+            $creditsReserved = true;
+
+            if (!$server) {
+                throw new \Exception('Server creation record failed to persist.');
+            }
+
             try {
                 $response = $this->pterodactylClient->createServer($server, $egg, $validatedData['allocation_id'], $validatedData['egg_variables'] ?? null);
 
                 if ($response->successful()) {
-                    return $this->handleProvisionSuccess($server, $response, $product->price);
+                    return $this->handleProvisionSuccess($server, $response, $credits);
                 }
 
-                return $this->handleProvisionFailure($server, $user, $product, $response);
-            } catch (\Exception $e) {
-                return $this->handleProvisionUncertain($server, $product->price, $e);
+                return $this->handleProvisionFailure($server, $user, $product, $response, $credits);
+            } catch (\Throwable $e) {
+                return $this->handleProvisionUncertain($server, $credits, $e);
             }
-        } catch (\Exception $e) {
-            if ($creditsReserved && is_null($server)) {
-                $this->refundCredits($user, $product->price);
+        } catch (\Throwable $e) {
+            if ($creditsReserved) {
+                if ($server) {
+                    if ($server->status !== Server::STATUS_ACTIVE && $server->status !== Server::STATUS_FAILED) {
+                        $server->update(['status' => Server::STATUS_PENDING_RECONCILIATION]);
+                        dispatch(new ReconcileServerCreationJob($server->id, $credits));
+                    }
+                } else {
+                    $this->refundCredits($user, $credits);
+                }
             }
-            throw new \Exception($e->getMessage());
+            throw $e;
         } finally {
             $lock->release();
         }
@@ -167,17 +187,17 @@ class ServerCreationService
         ];
     }
 
-    private function reserveCredits(User $user, float $price): void
+    private function reserveCredits(User $user, int $price): void
     {
         $this->creditService->reserve($user, $price);
     }
 
-    private function refundCredits(User $user, float $price): void
+    private function refundCredits(User $user, int $price): void
     {
         $this->creditService->refund($user, $price);
     }
 
-    private function handleProvisionSuccess(Server $server, $response, float $chargedPrice): Server
+    private function handleProvisionSuccess(Server $server, $response, int $chargedPrice): Server
     {
         $serverAttributes = $response->json()['attributes'] ?? null;
 
@@ -208,7 +228,7 @@ class ServerCreationService
         }
     }
 
-    private function handleProvisionFailure(Server $server, User $user, Product $product, $response): Server
+    private function handleProvisionFailure(Server $server, User $user, Product $product, $response, int $chargedPrice): Server
     {
         logger()->warning('Provisioning failed on Pterodactyl, re-checking remote state', [
             'server_id' => $server->id,
@@ -236,17 +256,17 @@ class ServerCreationService
             }
 
             if ($remoteResponse->status() === 404) {
-                $this->refundCredits($user, $product->price);
+                $this->refundCredits($user, $chargedPrice);
                 $server->update(['status' => Server::STATUS_FAILED]);
 
-                throw new \Exception('Server creation failed and did not exist on remote; user credits have been refunded.');
+                return $server;
             }
 
             $server->update(['status' => Server::STATUS_PENDING_RECONCILIATION]);
-            dispatch(new ReconcileServerCreationJob($server->id, $product->price));
+            dispatch(new ReconcileServerCreationJob($server->id, $chargedPrice));
 
             return $server;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return $this->handleProvisionUncertain($server, $product->price, $e);
         }
     }
@@ -259,7 +279,7 @@ class ServerCreationService
      * Pterodactyl state, so we mark the server as pending reconciliation and delegate
      * detailed error handling and state correction to ReconcileServerCreationJob.
      */
-    private function handleProvisionUncertain(Server $server, float $chargedPrice, \Exception $exception): Server
+    private function handleProvisionUncertain(Server $server, int $chargedPrice, \Throwable $exception): Server
     {
         logger()->warning('Provisioning uncertain, scheduling reconciliation', [
             'server_id' => $server->id,

--- a/app/Services/ServerCreationService.php
+++ b/app/Services/ServerCreationService.php
@@ -7,10 +7,15 @@ use App\Models\Server;
 use App\Models\User;
 use App\Models\Product;
 use App\Models\Pterodactyl\Node;
+use App\Jobs\PostServerCreationJob;
+use App\Jobs\ReconcileServerCreationJob;
+use App\Services\CreditService;
 use App\Settings\GeneralSettings;
 use App\Settings\PterodactylSettings;
 use App\Settings\ServerSettings;
 use App\Settings\UserSettings;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 
 class ServerCreationService
 {
@@ -19,6 +24,7 @@ class ServerCreationService
     private GeneralSettings $generalSettings;
     private ServerSettings $serverSettings;
     private PterodactylClient $pterodactylClient;
+    private CreditService $creditService;
 
     /**
      * Create a new class instance.
@@ -30,6 +36,7 @@ class ServerCreationService
         $this->generalSettings = app(GeneralSettings::class);
         $this->serverSettings = app(ServerSettings::class);
         $this->pterodactylClient = app(PterodactylClient::class, [$this->pterodactylSettings]);
+        $this->creditService = app(CreditService::class);
     }
 
     /**
@@ -46,41 +53,52 @@ class ServerCreationService
     {
         $egg = $product->eggs->firstWhere('id', $data['egg_id']);
 
+        $lockKey = "server_provisioning_user_{$user->id}";
+        $lock = Cache::lock($lockKey, 30);
+
+        if (!$lock->block(10)) {
+            throw new \Exception('Another provisioning request is in progress for this user.');
+        }
+
+        $server = null;
+        $creditsReserved = false;
+
         try {
             $validatedData = $this->validateAndPrepare($user, $product, $data);
 
-            $server = Server::create([
-                'name' => $data['name'],
-                'user_id' => $user->id,
-                'product_id' => $product->id,
-                'node_id' => $validatedData['node_id'],
-                'last_billed' => now(),
-                'billing_priority' => isset($data['billing_priority']) ? $data['billing_priority'] : $product->default_billing_priority,
-            ]);
+            DB::transaction(function () use ($user, $product, $validatedData, $data, &$server, &$creditsReserved) {
+                $this->reserveCredits($user, $product->price);
+                $creditsReserved = true;
 
-            $response = $this->pterodactylClient->createServer($server, $egg, $validatedData['allocation_id'], isset($data['egg_variables']) ? $data['egg_variables'] : null);
-
-            if ($response->failed()) {
-                logger()->error('Failed to create server on Pterodactyl', [
-                    'server_id' => $server->id,
-                    'status' => $response->status(),
-                    'error' => $response->json()
+                $server = Server::create([
+                    'name' => $data['name'],
+                    'user_id' => $user->id,
+                    'product_id' => $product->id,
+                    'node_id' => $validatedData['node_id'],
+                    'last_billed' => now(),
+                    'billing_priority' => $validatedData['billing_priority'],
+                    'status' => Server::STATUS_PROVISIONING,
                 ]);
+            });
 
-                $server->delete();
+            try {
+                $response = $this->pterodactylClient->createServer($server, $egg, $validatedData['allocation_id'], $validatedData['egg_variables'] ?? null);
 
-                throw new \Exception('Failed to create server on Pterodactyl: ' . $response->json()['errors'][0]['detail'] ?? 'Unknown error');
+                if ($response->successful()) {
+                    return $this->handleProvisionSuccess($server, $response, $product->price);
+                }
+
+                return $this->handleProvisionFailure($server, $user, $product, $response);
+            } catch (\Exception $e) {
+                return $this->handleProvisionUncertain($server, $product->price, $e);
             }
-
-            $serverAttributes = $response->json()['attributes'];
-            $server->update([
-                'pterodactyl_id' => $serverAttributes['id'],
-                'identifier' => $serverAttributes['identifier']
-            ]);
-
-            return $server;
         } catch (\Exception $e) {
+            if ($creditsReserved && is_null($server)) {
+                $this->refundCredits($user, $product->price);
+            }
             throw new \Exception($e->getMessage());
+        } finally {
+            $lock->release();
         }
     }
 
@@ -144,7 +162,114 @@ class ServerCreationService
         return [
             'allocation_id' => $allocationId,
             'node_id' => $availableNode->id,
+            'billing_priority' => $data['billing_priority'] ?? $product->default_billing_priority,
+            'egg_variables' => $data['egg_variables'] ?? null,
         ];
+    }
+
+    private function reserveCredits(User $user, float $price): void
+    {
+        $this->creditService->reserve($user, $price);
+    }
+
+    private function refundCredits(User $user, float $price): void
+    {
+        $this->creditService->refund($user, $price);
+    }
+
+    private function handleProvisionSuccess(Server $server, $response, float $chargedPrice): Server
+    {
+        $serverAttributes = $response->json()['attributes'] ?? null;
+
+        if (!$serverAttributes || !isset($serverAttributes['id']) || !isset($serverAttributes['identifier'])) {
+            throw new \Exception('Invalid response from Pterodactyl on server creation.');
+        }
+
+        try {
+            $server->update([
+                'pterodactyl_id' => $serverAttributes['id'],
+                'identifier' => $serverAttributes['identifier'],
+                'status' => Server::STATUS_ACTIVE,
+            ]);
+
+            dispatch(new PostServerCreationJob($server->id));
+
+            return $server;
+        } catch (\Throwable $e) {
+            logger()->error('Failed to persist successful provisioning state', [
+                'server_id' => $server->id,
+                'error' => $e->getMessage(),
+            ]);
+
+            $server->update(['status' => Server::STATUS_PENDING_RECONCILIATION]);
+            dispatch(new ReconcileServerCreationJob($server->id, $chargedPrice));
+
+            return $server;
+        }
+    }
+
+    private function handleProvisionFailure(Server $server, User $user, Product $product, $response): Server
+    {
+        logger()->warning('Provisioning failed on Pterodactyl, re-checking remote state', [
+            'server_id' => $server->id,
+            'status' => $response->status(),
+            'error' => $response->json(),
+        ]);
+
+        try {
+            $remoteResponse = $this->pterodactylClient->getServerByExternalId($server->id);
+
+            if ($remoteResponse->successful()) {
+                $remoteAttributes = $remoteResponse->json()['attributes'] ?? null;
+
+                if ($remoteAttributes && isset($remoteAttributes['id']) && isset($remoteAttributes['identifier'])) {
+                    $server->update([
+                        'pterodactyl_id' => $remoteAttributes['id'],
+                        'identifier' => $remoteAttributes['identifier'],
+                        'status' => Server::STATUS_ACTIVE,
+                    ]);
+
+                    dispatch(new PostServerCreationJob($server->id));
+
+                    return $server;
+                }
+            }
+
+            if ($remoteResponse->status() === 404) {
+                $this->refundCredits($user, $product->price);
+                $server->update(['status' => Server::STATUS_FAILED]);
+
+                throw new \Exception('Server creation failed and did not exist on remote; user credits have been refunded.');
+            }
+
+            $server->update(['status' => Server::STATUS_PENDING_RECONCILIATION]);
+            dispatch(new ReconcileServerCreationJob($server->id, $product->price));
+
+            return $server;
+        } catch (\Exception $e) {
+            return $this->handleProvisionUncertain($server, $product->price, $e);
+        }
+    }
+
+    /**
+     * Handle a provisioning state where the outcome is uncertain.
+     *
+     * The passed exception is intentionally only used for logging and is not rethrown
+     * or further analyzed here. At this point we cannot reliably determine the remote
+     * Pterodactyl state, so we mark the server as pending reconciliation and delegate
+     * detailed error handling and state correction to ReconcileServerCreationJob.
+     */
+    private function handleProvisionUncertain(Server $server, float $chargedPrice, \Exception $exception): Server
+    {
+        logger()->warning('Provisioning uncertain, scheduling reconciliation', [
+            'server_id' => $server->id,
+            'exception' => $exception->getMessage(),
+        ]);
+
+        $server->update(['status' => Server::STATUS_PENDING_RECONCILIATION]);
+        dispatch(new ReconcileServerCreationJob($server->id, $chargedPrice));
+
+        return $server;
     }
 
     private function findAvailableNode(string $locationId, Product $product): ?Node

--- a/app/Services/ServerCreationService.php
+++ b/app/Services/ServerCreationService.php
@@ -267,7 +267,7 @@ class ServerCreationService
 
             return $server;
         } catch (\Throwable $e) {
-            return $this->handleProvisionUncertain($server, $product->price, $e);
+            return $this->handleProvisionUncertain($server, $chargedPrice, $e);
         }
     }
 

--- a/database/migrations/2026_03_22_191634_add_provisioning_status_to_servers_table.php
+++ b/database/migrations/2026_03_22_191634_add_provisioning_status_to_servers_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration
 {
@@ -10,9 +11,14 @@ return new class extends Migration
     {
         Schema::table('servers', function (Blueprint $table) {
             if (!Schema::hasColumn('servers', 'status')) {
-                $table->string('status')->default('provisioning')->after('identifier')->index();
+                $table->string('status')->default('active')->after('identifier')->index();
             }
         });
+
+            DB::table('servers')
+                ->whereNull('status')
+                ->orWhere('status', '')
+                ->update(['status' => 'active']);
     }
 
     public function down()

--- a/database/migrations/2026_03_22_191634_add_provisioning_status_to_servers_table.php
+++ b/database/migrations/2026_03_22_191634_add_provisioning_status_to_servers_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            if (!Schema::hasColumn('servers', 'status')) {
+                $table->string('status')->default('provisioning')->after('identifier')->index();
+            }
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            if (Schema::hasColumn('servers', 'status')) {
+                $table->dropColumn('status');
+            }
+        });
+    }
+};

--- a/themes/default/views/servers/settings.blade.php
+++ b/themes/default/views/servers/settings.blade.php
@@ -262,8 +262,7 @@
                                 <!-- Upgrade Button trigger modal -->
                                 @if ($server_enable_upgrade && Auth::user()->can('user.server.upgrade'))
                                     <button type="button" data-toggle="modal"
-                                        data-target="#UpgradeModal{{ $server->id }}"
-                                        class="btn btn-info btn-md">
+                                        data-target="#UpgradeModal{{ $server->id }}" class="btn btn-info btn-md">
                                         <i class="mr-2 fas fa-upload"></i>
                                         <span>{{ __('Upgrade / Downgrade') }}</span>
                                     </button>
@@ -300,7 +299,7 @@
                                                                         @if ($product->doesNotFit) disabled @endif>
                                                                         {{ $product->name }} [ {{ $credits_display_name }}
                                                                         {{ $product->display_price }} @if ($product->doesNotFit)
-                                                                            ] {{ __('Server can't fit on this node') }}
+                                                                            ] {{ __("Server can't fit on this node") }}
                                                                         @else
                                                                             / {{ __('Required') }}:
                                                                             {{ $product->display_minimum_credits }}


### PR DESCRIPTION
## Problem
Server provisioning was previously handled as a single-step process with no clear state tracking or recovery path. Failures during API calls or database operations could lead to inconsistent states, such as users being charged without receiving a server or servers being created without proper tracking.

## Solution
- Introduce explicit server lifecycle states (`provisioning`, `active`, `failed`, `pending_reconciliation`)
- Implement a dedicated service to handle server creation, credit reservation, and failure recovery
- Add a reconciliation job to resolve uncertain or partial failures
- Introduce atomic credit handling to prevent race conditions and ensure safe refunds
- Improve verification of remote server state via external ID lookup

## Features
- Servers are created with a tracked provisioning lifecycle
- Users are only charged when provisioning is confirmed or safely handled
- Failed or uncertain provisioning attempts are automatically reconciled
- Remote server state is verified to prevent orphaned or duplicate servers
- Credit operations are atomic and protected against race conditions