### PR TITLE
Server balancer: auto-select node with free allocations (#1310)

### DIFF
--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -174,10 +174,10 @@ class ServerController extends Controller
     private function validateProductRequirements(Product $product, Request $request): string|bool
     {
         $location = $request->input('location');
-        $availableNode = $this->findAvailableNode($location, $product);
+        $nodeAllocation = $this->findAvailableNodeWithAllocation($location, $product);
 
-        if (!$availableNode) {
-            return __("The chosen location doesn't have the required memory or disk left to allocate this product.");
+        if (!$nodeAllocation) {
+            return __("The chosen location doesn't have the required memory, disk, or free allocations to allocate this product.");
         }
 
         $user = Auth::user();
@@ -272,9 +272,9 @@ class ServerController extends Controller
     {
         $product = Product::findOrFail($request->input('product'));
         $egg = $product->eggs()->findOrFail($request->input('egg'));
-        $node = $this->findAvailableNode($request->input('location'), $product);
+        $nodeAllocation = $this->findAvailableNodeWithAllocation($request->input('location'), $product);
 
-        if (!$node) return null;
+        if (!$nodeAllocation) return null;
 
         $server = $request->user()->servers()->create([
             'name' => $request->input('name'),
@@ -283,17 +283,7 @@ class ServerController extends Controller
             'billing_priority' => $request->input('billing_priority', $product->default_billing_priority),
         ]);
 
-        $allocationId = $this->pterodactyl->getFreeAllocationId($node);
-        if (!$allocationId) {
-            Log::error('No AllocationID found.', [
-                'server_id' => $server->id,
-                'node_id' => $node->id,
-            ]);
-            $server->delete();
-            return null;
-        }
-
-        $response = $this->pterodactyl->createServer($server, $egg, $allocationId, $request->input('egg_variables'));
+        $response = $this->pterodactyl->createServer($server, $egg, $nodeAllocation['allocation_id'], $request->input('egg_variables'));
         if ($response->failed()) {
             Log::error('Failed to create server on Pterodactyl', [
                 'server_id' => $server->id,
@@ -593,10 +583,51 @@ class ServerController extends Controller
             ->get();
 
         $availableNodes = $nodes->reject(function ($node) use ($product) {
-            return !$this->pterodactyl->checkNodeResources($node, $product->memory, $product->disk);
+            // Check if node has enough memory and disk resources
+            if (!$this->pterodactyl->checkNodeResources($node, $product->memory, $product->disk)) {
+                return true;
+            }
+
+            // Check if node has free allocations (IP/port)
+            $freeAllocations = $this->pterodactyl->getFreeAllocations($node);
+            return empty($freeAllocations);
         });
 
         return $availableNodes->isEmpty() ? null : $availableNodes->first();
+    }
+
+    /**
+     * Find a node in the given location for the product that has required resources
+     * and also a free allocation on Pterodactyl. Returns ['node' => Node, 'allocation_id' => int]
+     * or null when none available.
+     */
+    private function findAvailableNodeWithAllocation(string $locationId, Product $product): ?array
+    {
+        $nodes = Node::where('location_id', $locationId)
+            ->whereHas('products', fn($q) => $q->where('product_id', $product->id))
+            ->get();
+
+        $availableNodes = $nodes->reject(function ($node) use ($product) {
+            return !$this->pterodactyl->checkNodeResources($node, $product->memory, $product->disk);
+        });
+
+        foreach ($availableNodes as $node) {
+            try {
+                $allocationId = $this->pterodactyl->getFreeAllocationId($node);
+            } catch (\Exception $e) {
+                Log::warning('Failed to get allocation for node while searching for free allocation', [
+                    'node_id' => $node->id,
+                    'exception' => $e->getMessage(),
+                ]);
+                $allocationId = null;
+            }
+
+            if ($allocationId) {
+                return ['node' => $node, 'allocation_id' => $allocationId];
+            }
+        }
+
+        return null;
     }
 
     public function validateDeploymentVariables(Request $request)

--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -177,7 +177,7 @@ class ServerController extends Controller
         $nodeAllocation = $this->findAvailableNodeWithAllocation($location, $product);
 
         if (!$nodeAllocation) {
-            return __("The chosen location doesn't have the required memory, disk, or free allocations to allocate this product.");
+            return __("The selected location does not have the required memory, disk, or is overloaded.");
         }
 
         $user = Auth::user();

--- a/app/Services/ServerCreationService.php
+++ b/app/Services/ServerCreationService.php
@@ -154,9 +154,48 @@ class ServerCreationService
             ->get();
 
         $availableNodes = $nodes->reject(function ($node) use ($product) {
-            return !$this->pterodactylClient->checkNodeResources($node, $product->memory, $product->disk);
+            // Check if node has enough memory and disk resources
+            if (!$this->pterodactylClient->checkNodeResources($node, $product->memory, $product->disk)) {
+                return true;
+            }
+
+            // Check if node has free allocations (IP/port)
+            $freeAllocations = $this->pterodactylClient->getFreeAllocations($node);
+            return empty($freeAllocations);
         });
 
         return $availableNodes->isEmpty() ? null : $availableNodes->first();
+    }
+
+    /**
+     * Find a node in the given location for the product that has required resources
+     * and also a free allocation on Pterodactyl. Returns ['node' => Node, 'allocation_id' => int]
+     * or null when none available.
+     */
+    private function findAvailableNodeWithAllocation(string $locationId, Product $product): ?array
+    {
+        $nodes = Node::where('location_id', $locationId)
+            ->whereHas('products', fn($q) => $q->where('product_id', $product->id))
+            ->get();
+
+        $availableNodes = $nodes->reject(function ($node) use ($product) {
+            return !$this->pterodactylClient->checkNodeResources($node, $product->memory, $product->disk);
+        });
+
+        // Try each available node and return the first one with a free allocation.
+        foreach ($availableNodes as $node) {
+            try {
+                $allocationId = $this->pterodactylClient->getFreeAllocationId($node);
+            } catch (\Exception $e) {
+                logger('Failed to get allocation for node ' . $node->id, ['exception' => $e]);
+                $allocationId = null;
+            }
+
+            if ($allocationId) {
+                return ['node' => $node, 'allocation_id' => $allocationId];
+            }
+        }
+
+        return null;
     }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -71,7 +71,7 @@
     "Change Status": "Change Status",
     "Profile updated": "Profile updated",
     "Server limit reached!": "Server limit reached!",
-    "The chosen location doesn't have the required memory or disk left to allocate this product.": "The chosen location doesn't have the required memory or disk left to allocate this product.",
+    "The selected location does not have the required memory, disk, or is overloaded.": "The selected location does not have the required memory, disk, or is overloaded.",
     "You are required to verify your email address before you can create a server.": "You are required to verify your email address before you can create a server.",
     "You are required to link your discord account before you can create a server.": "You are required to link your discord account before you can create a server.",
     "Server created": "Server created",


### PR DESCRIPTION
## Problem
Server provisioning could fail when the selected node had no free IP/port allocations even though other nodes had available allocations. The previous selection logic validated only memory and disk resources, causing provisioning errors, ambiguous validation messages, and failed deployments when allocations were exhausted on the chosen node.

## Solution
- Validate IP/port allocation availability in node selection in addition to memory and disk.
- Add `findAvailableNodeWithAllocation` to locate nodes that have free allocations and satisfy resource constraints.
- Update `ServerController` to use `findAvailableNodeWithAllocation`; `ServerCreationService` adds the helper but retains a `findAvailableNode` + `getFreeAllocationId` flow (functionally allocation-aware, but usage differs).
- Surface explicit validation errors when no node with free allocations exists to avoid silent failures.
- Note: This commit does not add an explicit "server balancer" configuration flag; the fallback to another node with allocations is unconditional within the searched location (the helper provides an integration point for future balancer behavior).

## Features
- Node selection checks allocations as well as memory/disk.
- Automatic fallback to the first available node with a free allocation within the selected location (no balancer toggle implemented here).
- Clear validation error and failure handling when allocations are exhausted.
- Reduced provisioning failures and allocation conflicts during server creation.
- Adds `findAvailableNodeWithAllocation` as an integration point for the Server Balancer issue (#1310).