### PR TITLE
Fix/add server cancellation revoke

### DIFF
--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -388,24 +388,27 @@ class ServerController extends Controller
         }
     }
 
-    public function uncancel(Server $server): RedirectResponse
+    public function uncancel(Server $server): \Illuminate\Http\Response|RedirectResponse
     {
         if ($server->user_id !== Auth::id()) {
             return back()->with('error', __('This is not your Server!'));
         }
-
+    
         try {
             $server->update(['canceled' => null]);
-
-            if (request()->ajax()) {
-                return response()->json(['success' => __('Server cancellation has been revoked')]);
-            }
             
+            if (request()->expectsJson()) {
+                return response()->noContent(); 
+            }
+    
             return redirect()->route('servers.index')
                 ->with('success', __('Server cancellation has been revoked'));
         } catch (Exception $e) {
+            if (request()->expectsJson()) {
+                return response()->json(['error' => $e->getMessage()], 500);
+            }
             return redirect()->route('servers.index')
-                ->with('error', __('Server cancellation revoke failed: ') . $e->getMessage());
+                ->with('error', __('Server cancellation revoke failed'));
         }
     }
 

--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -396,6 +396,11 @@ class ServerController extends Controller
 
         try {
             $server->update(['canceled' => null]);
+
+            if (request()->ajax()) {
+                return response()->json(['success' => __('Server cancellation has been revoked')]);
+            }
+            
             return redirect()->route('servers.index')
                 ->with('success', __('Server cancellation has been revoked'));
         } catch (Exception $e) {

--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -403,8 +403,10 @@ class ServerController extends Controller
             return redirect()->route('servers.index')
                 ->with('success', __('Server cancellation has been revoked'));
         } catch (Exception $e) {
+            report($e);
+
             if (request()->expectsJson()) {
-                return response()->json(['error' => $e->getMessage()], 500);
+                return response()->json(['error' => __('Server cancellation revoke failed')], 500);
             }
             return redirect()->route('servers.index')
                 ->with('error', __('Server cancellation revoke failed'));

--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -1,4 +1,3 @@
-app/Http/Controllers/ServerController.php
 <?php
 
 namespace App\Http\Controllers;

--- a/themes/default/views/servers/index.blade.php
+++ b/themes/default/views/servers/index.blade.php
@@ -273,7 +273,7 @@
         const handleServerUncancel = (serverId) => {
             Swal.fire({
                 title: "{{ __('Restore Server?') }}",
-                text: "{{ __('This will restore your server and cancel the cancellation.') }}",
+                text: "{{ __('This will restore your server and cancel the cancellation. Your server will no longer be suspended at the end of the billing period.') }}",
                 icon: 'info',
                 showCancelButton: true,
                 confirmButtonColor: '#28a745',

--- a/themes/default/views/servers/index.blade.php
+++ b/themes/default/views/servers/index.blade.php
@@ -271,13 +271,12 @@
         }
 
         const handleServerUncancel = (serverId) => {
-            // Handle server uncancel with sweetalert
             Swal.fire({
                 title: "{{ __('Restore Server?') }}",
-                text: "{{ __('This will restore your server and cancel the cancellation. Your server will no longer be suspended at the end of the billing period.') }}",
+                text: "{{ __('This will restore your server and cancel the cancellation.') }}",
                 icon: 'info',
-                confirmButtonColor: '#28a745',
                 showCancelButton: true,
+                confirmButtonColor: '#28a745',
                 confirmButtonText: "{{ __('Yes, restore it!') }}",
                 cancelButtonText: "{{ __('No, abort!') }}",
                 reverseButtons: true
@@ -286,24 +285,26 @@
                     fetch("{{ route('servers.uncancel', '') }}" + '/' + serverId, {
                         method: 'PATCH',
                         headers: {
-                            'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                            'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                            'Accept': 'application/json',
+                            'X-Requested-With': 'XMLHttpRequest'
                         }
                     }).then((response) => {
-                        if (!response.ok) {
-                            throw new Error('Failed to restore server');
+                        if (response.ok) {
+                            window.location.reload();
+                        } else {
+                            throw new Error('Server error');
                         }
-                        window.location.reload();
                     }).catch((error) => {
                         Swal.fire({
                             title: "{{ __('Error') }}",
                             text: "{{ __('Something went wrong, please try again later.') }}",
                             icon: 'error',
                             confirmButtonColor: '#d9534f',
-                        })
-                    })
-                    return
+                        });
+                    });
                 }
-            })
+            });
         }
 
         const handleServerDelete = (serverId) => {


### PR DESCRIPTION
This pull request improves the server uncancel (restore) workflow by adding proper JSON response handling for API requests and updating the UI logic to better handle asynchronous operations and errors. The most important changes are grouped below:

**Backend: Improved API Response Handling**

* The `uncancel` method in `ServerController` now returns appropriate JSON or no-content responses for API requests, and provides a simplified error message for web redirects.

**Frontend: Enhanced Uncancel Workflow and Error Handling**

* The JavaScript function handling server uncancel now sends `Accept: application/json` and `X-Requested-With: XMLHttpRequest` headers to indicate an AJAX request, ensuring the backend returns the correct response type.
* The UI logic for uncancel now reloads the page on success and displays a clearer error message using SweetAlert if the request fails.
* The confirmation dialog text for restoring a server has been simplified for clarity.