### PR TITLE
added click event to close toast popups

### DIFF
--- a/themes/BlueInfinity/views/layouts/app.blade.php
+++ b/themes/BlueInfinity/views/layouts/app.blade.php
@@ -69,6 +69,7 @@
     didOpen: (toast) => {
       toast.addEventListener('mouseenter', Swal.stopTimer)
       toast.addEventListener('mouseleave', Swal.resumeTimer)
+      toast.addEventListener('click', () => Swal.close())
     }
   })
   @endif

--- a/themes/BlueInfinity/views/layouts/main.blade.php
+++ b/themes/BlueInfinity/views/layouts/main.blade.php
@@ -542,6 +542,7 @@
     didOpen: (toast) => {
       toast.addEventListener('mouseenter', Swal.stopTimer)
       toast.addEventListener('mouseleave', Swal.resumeTimer)
+      toast.addEventListener('click', () => Swal.close())
     }
   })
   @endif

--- a/themes/default/views/home.blade.php
+++ b/themes/default/views/home.blade.php
@@ -359,6 +359,7 @@
                         didOpen: (toast) => {
                             toast.addEventListener('mouseenter', Swal.stopTimer)
                             toast.addEventListener('mouseleave', Swal.resumeTimer)
+                            toast.addEventListener('click', () => Swal.close())
                         }
                     })
                 })

--- a/themes/default/views/layouts/app.blade.php
+++ b/themes/default/views/layouts/app.blade.php
@@ -69,6 +69,7 @@
             didOpen: (toast) => {
                 toast.addEventListener('mouseenter', Swal.stopTimer)
                 toast.addEventListener('mouseleave', Swal.resumeTimer)
+                toast.addEventListener('click', () => Swal.close())
             }
         })
     @endif

--- a/themes/default/views/layouts/main.blade.php
+++ b/themes/default/views/layouts/main.blade.php
@@ -555,6 +555,7 @@
         didOpen: (toast) => {
             toast.addEventListener('mouseenter', Swal.stopTimer)
             toast.addEventListener('mouseleave', Swal.resumeTimer)
+            toast.addEventListener('click', () => Swal.close())
         }
     })
     @endif

--- a/themes/default/views/profile/index.blade.php
+++ b/themes/default/views/profile/index.blade.php
@@ -361,6 +361,8 @@
                         didOpen: (toast) => {
                             toast.addEventListener('mouseenter', Swal.stopTimer)
                             toast.addEventListener('mouseleave', Swal.resumeTimer)
+                            toast.addEventListener('click', () => Swal.close())
+
                         }
                     })
                 })


### PR DESCRIPTION
💡 **Description**

its pretty standard to click notifications to close them, my simple mind is confused if this is not an option.
Please take extra care reviewing as I an not developer.
---

🛠️ **Type of Change**


- User interface (UI) improvement

---

🖼️ **Screenshots (if applicable)**

Imagine a toast notification not being there because I kicked it before it expired. 