### PR TITLE
Added deletion of exhausted coupons and refactored logic

### DIFF
--- a/app/Console/Commands/DeleteExpiredCoupons.php
+++ b/app/Console/Commands/DeleteExpiredCoupons.php
@@ -22,7 +22,7 @@ class DeleteExpiredCoupons extends Command
      *
      * @var string
      */
-    protected $description = 'Delete expired coupons from DB.';
+    protected $description = 'Delete expired and exhausted coupons from DB.';
 
     /**
      * Execute the console command.
@@ -31,20 +31,21 @@ class DeleteExpiredCoupons extends Command
      */
     public function handle(CouponSettings $couponSettings)
     {
+        // Delete expired coupons
         if ($couponSettings->delete_coupon_on_expires) {
-            $expired_coupons = Coupon::where('expires_at', '<=', Carbon::now(config('app.timezone')))->get();
-
-            foreach ($expired_coupons as $expired_coupon) {
-                $expired_coupon->delete();
-            }
+            Coupon::where('expires_at', '<=', Carbon::now(config('app.timezone')))
+                ->get()
+                ->each->delete();
         }
+
+        // Delete exhausted coupons (reached max uses)
         if ($couponSettings->delete_coupon_on_uses_reached) {
-            $exhausted_coupons = Coupon::where('max_uses', '!=', -1)->whereColumn('uses', '>=', 'max_uses')->get();
-
-            foreach ($exhausted_coupons as $exhausted_coupon) {
-                $exhausted_coupon->delete();
-            }
+            Coupon::where('max_uses', '>', 0)
+                ->whereColumn('uses', '>=', 'max_uses')
+                ->get()
+                ->each->delete();
         }
 
+        return Command::SUCCESS;
     }
 }

--- a/app/Console/Commands/DeleteExpiredCoupons.php
+++ b/app/Console/Commands/DeleteExpiredCoupons.php
@@ -38,5 +38,13 @@ class DeleteExpiredCoupons extends Command
                 $expired_coupon->delete();
             }
         }
+        if ($couponSettings->delete_coupon_on_uses_reached) {
+            $exhausted_coupons = Coupon::where('max_uses', '!=', -1)->whereColumn('uses', '>=', 'max_uses')->get();
+
+            foreach ($exhausted_coupons as $exhausted_coupon) {
+                $exhausted_coupon->delete();
+            }
+        }
+
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -31,7 +31,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('servers:notify-suspension')->daily();
         $schedule->command('cp:versioncheck:get')->daily();
         $schedule->command('payments:open:clear')->daily();
-        $schedule->command('coupons:delete')->daily();
+        $schedule->command('coupons:delete')->hourly();
 
         //log cronjob activity
         $schedule->call(function () {


### PR DESCRIPTION
💡 **Description**

For a few edgecase reasons the coupon cleanup ignored coupons with max uses exhausted.

1. due to old errors i had a bunch from failed transactions
2. if value is changed after uses to less than current uses, it should be exhausted and cleaned up (if setting is set.) 
3. if you used the panel for a while, and turned the delete setting on after coupons had become exhausted or expired. 

---

🛠️ **Type of Change**

Please select the appropriate type of change:

- Bug fix (non-breaking change which fixes an issue)
- UX improvement?

---

**Tested**
turned both settings off , tested letting coupons expire and hit max usage : nothing was deleted
turned settings on : after a while expired and exhausted coupons deleted
set a coupon to expire : it deleted after a while
used a ticket with a usage limit of 1 : it deleted instantly