### PR TITLE
fix: server creation error handling

### DIFF
--- a/app/Http/Controllers/Admin/ServerController.php
+++ b/app/Http/Controllers/Admin/ServerController.php
@@ -236,42 +236,77 @@ class ServerController extends Controller
     public function syncServers()
     {
         $this->checkPermission(self::WRITE_PERMISSION);
-        $CPServers = Server::get();
+        $CPServers = Server::all();
 
         $CPIDArray = [];
         $renameCount = 0;
-        foreach ($CPServers as $CPServer) { //go thru all CP servers and make array with IDs as keys. All values are false.
+        $recoveredCount = 0;
+        $deleteCount = 0;
+
+        // 1. Handle servers with missing pterodactyl_id (Try to recover via external_id)
+        foreach ($CPServers->whereNull('pterodactyl_id') as $serverWithoutId) {
+            try {
+                $response = $this->pterodactyl->getServerByExternalId($serverWithoutId->id);
+                if ($response->successful()) {
+                    $attributes = $response->json()['attributes'] ?? null;
+                    if ($attributes && isset($attributes['id'])) {
+                        $serverWithoutId->update([
+                            'pterodactyl_id' => $attributes['id'],
+                            'identifier' => $attributes['identifier'] ?? $serverWithoutId->identifier,
+                            'status' => Server::STATUS_ACTIVE,
+                        ]);
+                        $recoveredCount++;
+                    }
+                }
+            } catch (Exception $e) {
+                Log::error("Failed to sync server without ID {$serverWithoutId->id}: " . $e->getMessage());
+            }
+        }
+
+        // Refresh list after recovery attempts
+        $CPServers = Server::all();
+
+        // 2. Map existing pterodactyl_id for presence check
+        foreach ($CPServers as $CPServer) {
             if ($CPServer->pterodactyl_id) {
                 $CPIDArray[$CPServer->pterodactyl_id] = false;
             }
         }
 
-        foreach ($this->pterodactyl->getServers() as $server) { //go thru all ptero servers, if server exists, change value to true in array.
-            if (isset($CPIDArray[$server['attributes']['id']])) {
-                $CPIDArray[$server['attributes']['id']] = true;
+        // 3. Sync names and mark found servers
+        foreach ($this->pterodactyl->getServers() as $server) {
+            $pteroId = $server['attributes']['id'];
+            if (isset($CPIDArray[$pteroId])) {
+                $CPIDArray[$pteroId] = true;
 
-                if (isset($server['attributes']['name'])) { //failsafe
-                    //Check if a server got renamed
-                    $savedServer = Server::query()->where('pterodactyl_id', $server['attributes']['id'])->first();
-                    if ($savedServer->name != $server['attributes']['name']) {
-                        $savedServer->name = $server['attributes']['name'];
-                        $savedServer->save();
+                if (isset($server['attributes']['name'])) {
+                    $savedServer = $CPServers->where('pterodactyl_id', $pteroId)->first();
+                    if ($savedServer && $savedServer->name != $server['attributes']['name']) {
+                        $savedServer->update(['name' => $server['attributes']['name']]);
                         $renameCount++;
                     }
                 }
             }
         }
-        $filteredArray = array_filter($CPIDArray, function ($v, $k) {
-            return $v == false;
-        }, ARRAY_FILTER_USE_BOTH); //Array of servers, that dont exist on ptero (value == false)
-        $deleteCount = 0;
-        foreach ($filteredArray as $key => $CPID) { //delete servers that dont exist on ptero anymore
-            if (!$this->pterodactyl->getServerAttributes($key, true)) {
+
+        // 4. Delete servers that don't exist on Pterodactyl anymore
+        $orphanedServers = array_filter($CPIDArray, fn($found) => !$found);
+        foreach ($orphanedServers as $key => $found) {
+            try {
+                // getServerAttributes with deleteOn404=true will delete the server if it's missing
+                $this->pterodactyl->getServerAttributes($key, true);
                 $deleteCount++;
+            } catch (Exception $e) {
+                Log::error("Failed to check orphaned server {$key}: " . $e->getMessage());
             }
         }
 
-        return redirect()->back()->with('success', __('Servers synced successfully' . (($renameCount) ? (',\n' . __('renamed') . ' ' . $renameCount . ' ' . __('servers')) : '') . ((count($filteredArray)) ? (',\n' . __('deleted') . ' ' . $deleteCount . '/' . count($filteredArray) . ' ' . __('old servers')) : ''))) . '.';
+        $message = __('Servers synced successfully.');
+        if ($renameCount > 0) $message .= ' ' . __('Renamed') . ': ' . $renameCount . '.';
+        if ($recoveredCount > 0) $message .= ' ' . __('Recovered') . ': ' . $recoveredCount . '.';
+        if ($deleteCount > 0) $message .= ' ' . __('Deleted') . ': ' . $deleteCount . '.';
+
+        return redirect()->back()->with('success', $message);
     }
 
     /**

--- a/app/Http/Controllers/Admin/ServerController.php
+++ b/app/Http/Controllers/Admin/ServerController.php
@@ -9,6 +9,8 @@ use App\Settings\DiscordSettings;
 use App\Settings\LocaleSettings;
 use App\Settings\PterodactylSettings;
 use App\Classes\PterodactylClient;
+use App\Facades\Currency;
+use App\Services\CreditService;
 use Exception;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\View\Factory;
@@ -154,9 +156,11 @@ class ServerController extends Controller
      * Remove the specified resource from storage.
      *
      * @param  Server  $server
+     * @param  Request  $request
+     * @param  DiscordSettings  $discord_settings
      * @return RedirectResponse|Response
      */
-    public function destroy(Server $server, DiscordSettings $discord_settings)
+    public function destroy(Server $server, Request $request, DiscordSettings $discord_settings)
     {
         $this->checkPermission(self::DELETE_PERMISSION);
         try {
@@ -171,6 +175,17 @@ class ServerController extends Controller
                 }
             } catch (Exception $e) {
                 log::debug('Failed to update discord roles' . $e->getMessage());
+            }
+
+            if ($request->has('refund')) {
+                $user = User::findOrFail($server->user_id);
+                $credits = (int) round($server->product->price);
+                app(CreditService::class)->refund($user, $credits);
+
+                activity()
+                    ->performedOn($server)
+                    ->causedBy(Auth::user())
+                    ->log("Server credits (" . Currency::formatForDisplay($credits) . ") refunded to user " . $user->name . " during deletion.");
             }
 
             // Attempt to remove the server from pterodactyl
@@ -364,11 +379,16 @@ class ServerController extends Controller
                         </button>
                        </form>
 
-                       <form class="d-inline" onsubmit="return submitResult();" method="post" action="' . route('admin.servers.destroy', $server->id) . '">
-                            ' . csrf_field() . '
-                            ' . method_field('DELETE') . '
-                           <button data-content="' . __('Delete') . '" data-toggle="popover" data-trigger="hover" data-placement="top" class="btn btn-sm btn-danger mr-1"><i class="fas fa-trash"></i></button>
-                       </form>
+                       <button data-content="' . __('Delete') . '"
+                               data-toggle="popover"
+                               data-trigger="hover"
+                               data-placement="top"
+                               class="btn btn-sm btn-danger mr-1 delete-server-btn"
+                               data-server-id="' . $server->id . '"
+                               data-server-status="' . $server->status . '"
+                               data-action="' . route('admin.servers.destroy', $server->id) . '">
+                           <i class="fas fa-trash"></i>
+                       </button>
 
                 ';
             })

--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -157,6 +157,11 @@ class ServerController extends Controller
                     ->with('error', __('Server creation failed'));
             }
 
+            if ($server->status === Server::STATUS_PENDING_RECONCILIATION) {
+                return redirect()->route('servers.index')
+                    ->with('success', __('Server is being created, please wait.'));
+            }
+
             return redirect()->route('servers.index')
                 ->with('success', __('Server created'));
         } catch (Exception $e) {
@@ -248,8 +253,14 @@ class ServerController extends Controller
         $servers = Auth::user()->servers;
 
         foreach ($servers as $server) {
+            if (!$server->pterodactyl_id) {
+                continue;
+            }
+
             $serverInfo = $this->pterodactyl->getServerAttributes($server->pterodactyl_id);
-            if (!$serverInfo) continue;
+            if (!$serverInfo) {
+                continue;
+            }
 
             $this->updateServerInfo($server, $serverInfo);
         }
@@ -315,6 +326,11 @@ class ServerController extends Controller
             return back()->with('error', __('This is not your Server!'));
         }
 
+        if (!$server->pterodactyl_id) {
+            return redirect()->route('servers.index')
+                ->with('error', __('Server is not ready yet. Please wait until it is created.'));
+        }
+
         try {
             $serverInfo = $this->pterodactyl->getServerAttributes($server->pterodactyl_id);
 
@@ -360,6 +376,11 @@ class ServerController extends Controller
             return back()->with('error', __('This is not your Server!'));
         }
 
+        if (!$server->pterodactyl_id) {
+            return redirect()->route('servers.index')
+                ->with('error', __('Server is not ready yet. Please wait until it is created.'));
+        }
+
         try {
             $server->update(['canceled' => now()]);
             return redirect()->route('servers.index')
@@ -370,10 +391,15 @@ class ServerController extends Controller
         }
     }
 
-    public function show(Server $server): \Illuminate\View\View
+    public function show(Server $server): \Illuminate\View\View|RedirectResponse
     {
         if ($server->user_id !== Auth::id()) {
             return back()->with('error', __('This is not your Server!'));
+        }
+
+        if (!$server->pterodactyl_id) {
+            return redirect()->route('servers.index')
+                ->with('error', __('Server is not ready yet. Please wait until it is created.'));
         }
 
         $serverAttributes = $this->pterodactyl->getServerAttributes($server->pterodactyl_id);
@@ -434,6 +460,11 @@ class ServerController extends Controller
                 ->with('error', __('This is not your Server!'));
         }
 
+        if (!$server->pterodactyl_id) {
+            return redirect()->route('servers.index')
+                ->with('error', __('Server is not ready yet. Please wait until it is created.'));
+        }
+
         if (!$request->has('product_upgrade')) {
             return redirect()->route('servers.show', ['server' => $server->id])
                 ->with('error', __('No product selected for upgrade'));
@@ -481,6 +512,11 @@ class ServerController extends Controller
                 ->with('error', __('This is not your Server!'));
         }
 
+        if (!$server->pterodactyl_id) {
+            return redirect()->route('servers.index')
+                ->with('error', __('Server is not ready yet. Please wait until it is created.'));
+        }
+
         $server->update($data);
 
         return redirect()->route('servers.show', ['server' => $server->id])
@@ -491,6 +527,10 @@ class ServerController extends Controller
     {
         $user = Auth::user();
         if (!$server->product) {
+            return false;
+        }
+
+        if (!$server->pterodactyl_id) {
             return false;
         }
 

--- a/app/Jobs/ReconcileServerCreationJob.php
+++ b/app/Jobs/ReconcileServerCreationJob.php
@@ -114,38 +114,34 @@ class ReconcileServerCreationJob implements ShouldQueue
                     ]);
                     dispatch(new PostServerCreationJob($server->id));
 
-                    Log::critical('ReconcileServerCreationJob failed after retries but remote server found; marked active', [
+                    Log::critical('ReconcileServerCreationJob exhausted retries but remote server finally found; marked active', [
                         'server_id' => $this->serverId,
-                        'error' => $exception->getMessage(),
                     ]);
                     return;
                 }
             }
 
-            if ($response->status() === 404) {
-                $server->delete();
-                $creditService->refund($server->user, $this->chargedPrice);
-                Log::critical('ReconcileServerCreationJob failed after retries with remote 404; deleted server and refunded credits', [
-                    'server_id' => $this->serverId,
-                    'amount' => $this->chargedPrice,
-                    'error' => $exception->getMessage(),
-                ]);
-
-                return;
-            }
-
-            $server->update(['status' => Server::STATUS_PENDING_RECONCILIATION]);
-            Log::critical('ReconcileServerCreationJob failed after maximum retries; remote state unknown, keeping pending_reconciliation', [
+            // If we are here, we either got a 404 or a persistent API error (500/timeout)
+            // after many retries. We satisfy the "automatic" requirement by cleaning up.
+            $server->delete();
+            $creditService->refund($server->user, $this->chargedPrice);
+            
+            Log::critical('ReconcileServerCreationJob exhausted retries and could not confirm server; auto-deleted and refunded', [
                 'server_id' => $this->serverId,
+                'amount' => $this->chargedPrice,
                 'error' => $exception->getMessage(),
             ]);
+
         } catch (\Exception $e) {
-            // If remote check also fails, preserve pending state and log.
-            $server->update(['status' => Server::STATUS_PENDING_RECONCILIATION]);
-            Log::critical('ReconcileServerCreationJob failed and remote check failed; keeping pending_reconciliation', [
-                'server_id' => $this->serverId,
-                'exception' => $e->getMessage(),
-            ]);
+            // Even if the final check fails, we delete and refund to avoid "stuck" servers.
+            if ($server->exists) {
+                $server->delete();
+                $creditService->refund($server->user, $this->chargedPrice);
+                Log::critical('ReconcileServerCreationJob failed critically (even final check); forced delete and refund', [
+                    'server_id' => $this->serverId,
+                    'exception' => $e->getMessage()
+                ]);
+            }
         }
     }
 }

--- a/app/Jobs/ReconcileServerCreationJob.php
+++ b/app/Jobs/ReconcileServerCreationJob.php
@@ -78,18 +78,12 @@ class ReconcileServerCreationJob implements ShouldQueue
         }
 
         if ($response->status() === 404) {
-            // Atomic transition to FAILED to avoid double refunds in concurrent workers.
-            $updated = Server::where('id', $server->id)
-                ->where('status', '!=', Server::STATUS_FAILED)
-                ->update(['status' => Server::STATUS_FAILED]);
-
-            if ($updated === 1) {
-                $creditService->refund($server->user, $this->chargedPrice);
-                Log::info('ReconcileServerCreationJob: refunded credits on confirmed 404', [
-                    'server_id' => $server->id,
-                    'amount' => $this->chargedPrice,
-                ]);
-            }
+            $server->delete();
+            $creditService->refund($server->user, $this->chargedPrice);
+            Log::info('ReconcileServerCreationJob: deleted server and refunded credits on confirmed 404', [
+                'server_id' => $this->serverId,
+                'amount' => $this->chargedPrice,
+            ]);
 
             return;
         }
@@ -129,22 +123,13 @@ class ReconcileServerCreationJob implements ShouldQueue
             }
 
             if ($response->status() === 404) {
-                $updated = Server::where('id', $server->id)
-                    ->where('status', '!=', Server::STATUS_FAILED)
-                    ->update(['status' => Server::STATUS_FAILED]);
-
-                if ($updated === 1) {
-                    $creditService->refund($server->user, $this->chargedPrice);
-                    Log::critical('ReconcileServerCreationJob failed after retries with remote 404; refunded credits', [
-                        'server_id' => $this->serverId,
-                        'amount' => $this->chargedPrice,
-                        'error' => $exception->getMessage(),
-                    ]);
-                } else {
-                    Log::info('ReconcileServerCreationJob failed after retries with remote 404; no refund needed because status already failed', [
-                        'server_id' => $this->serverId,
-                    ]);
-                }
+                $server->delete();
+                $creditService->refund($server->user, $this->chargedPrice);
+                Log::critical('ReconcileServerCreationJob failed after retries with remote 404; deleted server and refunded credits', [
+                    'server_id' => $this->serverId,
+                    'amount' => $this->chargedPrice,
+                    'error' => $exception->getMessage(),
+                ]);
 
                 return;
             }

--- a/app/Services/ServerCreationService.php
+++ b/app/Services/ServerCreationService.php
@@ -239,10 +239,9 @@ class ServerCreationService
         ]);
 
         // If Pterodactyl returned a 400 Bad Request, it means the request was invalid (e.g. missing variables).
-        // In this case, we know the server wasn't created, so we can immediately delete it and refund.
+        // In this case, we know the server wasn't created, so we can immediately delete it.
         if ($response->status() === 400) {
             $server->delete();
-            $this->refundCredits($user, $chargedPrice);
 
             throw new \Exception(__('Server could not be created, please try again later or contact administration if the issue persists.'));
         }
@@ -268,7 +267,6 @@ class ServerCreationService
 
             if ($remoteResponse->status() === 404) {
                 $server->delete();
-                $this->refundCredits($user, $chargedPrice);
 
                 throw new \Exception(__('Server could not be created, please try again later or contact administration if the issue persists.'));
             }

--- a/app/Services/ServerCreationService.php
+++ b/app/Services/ServerCreationService.php
@@ -98,23 +98,23 @@ class ServerCreationService
 
             try {
                 $response = $this->pterodactylClient->createServer($server, $egg, $validatedData['allocation_id'], $validatedData['egg_variables']);
-
-                if ($response->successful()) {
-                    return $this->handleProvisionSuccess($server, $response, $credits);
-                }
-
-                return $this->handleProvisionFailure($server, $user, $product, $response, $credits);
             } catch (\Throwable $e) {
                 return $this->handleProvisionUncertain($server, $credits, $e);
             }
+
+            if ($response->successful()) {
+                return $this->handleProvisionSuccess($server, $response, $credits);
+            }
+
+            return $this->handleProvisionFailure($server, $user, $product, $response, $credits);
         } catch (\Throwable $e) {
             if ($creditsReserved) {
-                if ($server) {
+                if ($server && $server->exists) {
                     if ($server->status !== Server::STATUS_ACTIVE && $server->status !== Server::STATUS_FAILED) {
                         $server->update(['status' => Server::STATUS_PENDING_RECONCILIATION]);
                         dispatch(new ReconcileServerCreationJob($server->id, $credits));
                     }
-                } else {
+                } elseif (!$server || !$server->exists) {
                     $this->refundCredits($user, $credits);
                 }
             }
@@ -232,11 +232,20 @@ class ServerCreationService
 
     private function handleProvisionFailure(Server $server, User $user, Product $product, $response, int $chargedPrice): Server
     {
-        logger()->warning('Provisioning failed on Pterodactyl, re-checking remote state', [
+        logger()->error('Server creation failed on Pterodactyl (Permanent Error)', [
             'server_id' => $server->id,
             'status' => $response->status(),
             'error' => $response->json(),
         ]);
+
+        // If Pterodactyl returned a 400 Bad Request, it means the request was invalid (e.g. missing variables).
+        // In this case, we know the server wasn't created, so we can immediately delete it and refund.
+        if ($response->status() === 400) {
+            $server->delete();
+            $this->refundCredits($user, $chargedPrice);
+
+            throw new \Exception(__('Server could not be created, please try again later or contact administration if the issue persists.'));
+        }
 
         try {
             $remoteResponse = $this->pterodactylClient->getServerByExternalId($server->id);
@@ -258,16 +267,10 @@ class ServerCreationService
             }
 
             if ($remoteResponse->status() === 404) {
-                // Atomic status transition to avoid double refund when update fails.
-                $updated = Server::where('id', $server->id)
-                    ->where('status', '!=', Server::STATUS_FAILED)
-                    ->update(['status' => Server::STATUS_FAILED]);
+                $server->delete();
+                $this->refundCredits($user, $chargedPrice);
 
-                if ($updated === 1) {
-                    $this->refundCredits($user, $chargedPrice);
-                }
-
-                return $server;
+                throw new \Exception(__('Server could not be created, please try again later or contact administration if the issue persists.'));
             }
 
             $server->update(['status' => Server::STATUS_PENDING_RECONCILIATION]);
@@ -275,21 +278,19 @@ class ServerCreationService
 
             return $server;
         } catch (\Throwable $e) {
+            if ($e instanceof \Exception) {
+                throw $e;
+            }
             return $this->handleProvisionUncertain($server, $chargedPrice, $e);
         }
     }
 
     /**
-     * Handle a provisioning state where the outcome is uncertain.
-     *
-     * The passed exception is intentionally only used for logging and is not rethrown
-     * or further analyzed here. At this point we cannot reliably determine the remote
-     * Pterodactyl state, so we mark the server as pending reconciliation and delegate
-     * detailed error handling and state correction to ReconcileServerCreationJob.
+     * Handle a provisioning state where the outcome is uncertain (e.g. timeout, 500).
      */
     private function handleProvisionUncertain(Server $server, int $chargedPrice, \Throwable $exception): Server
     {
-        logger()->warning('Provisioning uncertain, scheduling reconciliation', [
+        logger()->warning('Provisioning uncertain (Timeout/Transient error), scheduling reconciliation', [
             'server_id' => $server->id,
             'exception' => $exception->getMessage(),
         ]);

--- a/app/Services/ServerCreationService.php
+++ b/app/Services/ServerCreationService.php
@@ -106,7 +106,7 @@ class ServerCreationService
                 return $this->handleProvisionSuccess($server, $response, $credits);
             }
 
-            return $this->handleProvisionFailure($server, $user, $product, $response, $credits);
+            return $this->handleProvisionFailure($server, $response, $credits);
         } catch (\Throwable $e) {
             if ($creditsReserved) {
                 if ($server && $server->exists) {
@@ -230,7 +230,7 @@ class ServerCreationService
         }
     }
 
-    private function handleProvisionFailure(Server $server, User $user, Product $product, $response, int $chargedPrice): Server
+    private function handleProvisionFailure(Server $server, $response, int $chargedPrice): Server
     {
         logger()->error('Server creation failed on Pterodactyl (Permanent Error)', [
             'server_id' => $server->id,
@@ -317,37 +317,5 @@ class ServerCreationService
         });
 
         return $availableNodes->isEmpty() ? null : $availableNodes->first();
-    }
-
-    /**
-     * Find a node in the given location for the product that has required resources
-     * and also a free allocation on Pterodactyl. Returns ['node' => Node, 'allocation_id' => int]
-     * or null when none available.
-     */
-    private function findAvailableNodeWithAllocation(string $locationId, Product $product): ?array
-    {
-        $nodes = Node::where('location_id', $locationId)
-            ->whereHas('products', fn($q) => $q->where('product_id', $product->id))
-            ->get();
-
-        $availableNodes = $nodes->reject(function ($node) use ($product) {
-            return !$this->pterodactylClient->checkNodeResources($node, $product->memory, $product->disk);
-        });
-
-        // Try each available node and return the first one with a free allocation.
-        foreach ($availableNodes as $node) {
-            try {
-                $allocationId = $this->pterodactylClient->getFreeAllocationId($node);
-            } catch (\Exception $e) {
-                logger('Failed to get allocation for node ' . $node->id, ['exception' => $e]);
-                $allocationId = null;
-            }
-
-            if ($allocationId) {
-                return ['node' => $node, 'allocation_id' => $allocationId];
-            }
-        }
-
-        return null;
     }
 }

--- a/themes/default/views/admin/servers/table.blade.php
+++ b/themes/default/views/admin/servers/table.blade.php
@@ -16,12 +16,8 @@
 </table>
 
 <script>
-    function submitResult() {
-        return confirm("{{ __('Are you sure you wish to delete?') }}") !== false;
-    }
-
     document.addEventListener("DOMContentLoaded", function() {
-        $('#datatable').DataTable({
+        const table = $('#datatable').DataTable({
             language: {
                 url: '//cdn.datatables.net/plug-ins/1.11.3/i18n/{{ config('SETTINGS::LOCALE:DATATABLES') }}.json'
             },
@@ -66,6 +62,68 @@
             fnDrawCallback: function(oSettings) {
                 $('[data-toggle="popover"]').popover();
             }
+        });
+
+        $(document).on('click', '.delete-server-btn', function() {
+            const serverId = $(this).data('server-id');
+            const action = $(this).data('action');
+
+            let swalOptions = {
+                title: "{{ __('Are you sure?') }}",
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonColor: '#d33',
+                cancelButtonColor: '#3085d6',
+                confirmButtonText: "{{ __('Yes, delete it!') }}",
+                cancelButtonText: "{{ __('Cancel') }}",
+                reverseButtons: true,
+                html: `
+                    <p>{{ __('Do you want to delete this server?') }}</p>
+                    <div class="custom-control custom-checkbox">
+                        <input type="checkbox" class="custom-control-input" id="refund-credits">
+                        <label class="custom-control-label" for="refund-credits">
+                            {{ __('Refund credits?') }}
+                            <i data-toggle="popover" data-trigger="hover" data-placement="top" data-content="{{ __('Only the price for one billing period will be refunded.') }}" class="fas fa-info-circle text-white"></i>
+                        </label>
+                    </div>
+                `,
+                didOpen: () => {
+                    $('[data-toggle="popover"]').popover();
+                }
+            };
+
+            Swal.fire(swalOptions).then((result) => {
+                if (result.isConfirmed) {
+                    const refund = document.getElementById('refund-credits')?.checked;
+                    const form = document.createElement('form');
+                    form.method = 'POST';
+                    form.action = action;
+
+                    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+                    const csrfInput = document.createElement('input');
+                    csrfInput.type = 'hidden';
+                    csrfInput.name = '_token';
+                    csrfInput.value = csrfToken;
+                    form.appendChild(csrfInput);
+
+                    const methodInput = document.createElement('input');
+                    methodInput.type = 'hidden';
+                    methodInput.name = '_method';
+                    methodInput.value = 'DELETE';
+                    form.appendChild(methodInput);
+
+                    if (refund) {
+                        const refundInput = document.createElement('input');
+                        refundInput.type = 'hidden';
+                        refundInput.name = 'refund';
+                        refundInput.value = '1';
+                        form.appendChild(refundInput);
+                    }
+
+                    document.body.appendChild(form);
+                    form.submit();
+                }
+            });
         });
     });
 </script>

--- a/themes/default/views/servers/index.blade.php
+++ b/themes/default/views/servers/index.blade.php
@@ -47,7 +47,6 @@
 
             <div class="flex-row row d-flex justify-content-center justify-content-md-start">
                 @foreach ($servers as $server)
-                 @if($server->location && $server->node && $server->nest && $server->egg)
                     <div class="pl-0 pr-0 col-xl-3 col-lg-5 col-md-6 col-sm-6 col-xs-12 card ml-sm-2 mr-sm-3"
                         style="max-width: 350px">
                         <div class="card-header">
@@ -60,7 +59,13 @@
                                 <div class="mb-3 row">
                                     <div class="my-auto col">{{ __('Status') }}:</div>
                                     <div class="my-auto col-7">
-                                        @if($server->suspended)
+                                        @if($server->status === 'provisioning')
+                                            <span class="badge badge-info">{{ __('Provisioning') }}</span>
+                                        @elseif($server->status === 'pending_reconciliation')
+                                            <span class="badge badge-info">{{ __('Reconciling') }}</span>
+                                        @elseif($server->status === 'failed')
+                                            <span class="badge badge-danger">{{ __('Failed') }}</span>
+                                        @elseif($server->suspended)
                                             <span class="badge badge-danger">{{ __('Suspended') }}</span>
                                         @elseif($server->canceled)
                                             <span class="badge badge-warning">{{ __('Canceled') }}</span>
@@ -74,9 +79,9 @@
                                         {{ __('Location') }}:
                                     </div>
                                     <div class="col-7 d-flex justify-content-between align-items-center">
-                                        <span class="">{{ $server->location }}</span>
+                                        <span class="">{{ $server->location ?? __('Unknown') }}</span>
                                         <i data-toggle="popover" data-trigger="hover"
-                                            data-content="{{ __('Node') }}: {{ $server->node }}"
+                                            data-content="{{ __('Node') }}: {{ $server->node ?? __('Unknown') }}"
                                             class="fas fa-info-circle"></i>
                                     </div>
 
@@ -86,7 +91,7 @@
                                         {{ __('Software') }}:
                                     </div>
                                     <div class="col-7 text-wrap">
-                                        <span>{{ $server->nest }}</span>
+                                        <span>{{ $server->nest ?? __('Unknown') }}</span>
                                     </div>
 
                                 </div>
@@ -95,7 +100,7 @@
                                         {{ __('Specification') }}:
                                     </div>
                                     <div class="col-7 text-wrap">
-                                        <span>{{ $server->egg }}</span>
+                                        <span>{{ $server->egg ?? __('Unknown') }}</span>
                                     </div>
                                 </div>
                                 <div class="mb-2 row">
@@ -117,7 +122,7 @@
                                     </div>
                                     <div class="col-7 d-flex text-wrap align-items-center">
                                         <span>
-                                        @if ($server->suspended)
+                                        @if ($server->suspended || !$server->pterodactyl_id)
                                             -
                                         @else
                                             @switch($server->product->billing_period)
@@ -187,31 +192,31 @@
                         </div>
 
                         <div class="text-center card-footer">
-                            <a href="{{ $pterodactyl_url }}/server/{{ $server->identifier }}"
+                            <a href="{{ $server->identifier ? $pterodactyl_url . '/server/' . $server->identifier : '#' }}"
                                 target="__blank"
-                                class="float-left ml-2 text-center btn btn-info"
+                                class="float-left ml-2 text-center btn btn-info {{ !$server->identifier ? 'disabled' : '' }}"
                                 data-toggle="tooltip" data-placement="bottom" title="{{ __('Manage Server') }}">
                                 <i class="mx-2 fas fa-tools"></i>
                             </a>
-                            <a href="{{ route('servers.show', ['server' => $server->id])}}"
-                            	class="mr-3 text-center btn btn-info"
+                            <a href="{{ $server->pterodactyl_id ? route('servers.show', ['server' => $server->id]) : '#' }}"
+                            	class="mr-3 text-center btn btn-info {{ !$server->pterodactyl_id ? 'disabled' : '' }}"
                             	data-toggle="tooltip" data-placement="bottom" title="{{ __('Server Settings') }}">
                                 <i class="mx-2 fas fa-cog"></i>
                             </a>
                             <button onclick="handleServerCancel('{{ $server->id }}');" target="__blank"
                                 class="text-center btn btn-warning"
-                                {{ $server->suspended || $server->canceled ? "disabled" : "" }}
+                                {{ $server->suspended || $server->canceled || !$server->pterodactyl_id ? "disabled" : "" }}
                                 data-toggle="tooltip" data-placement="bottom" title="{{ __('Cancel Server') }}">
                                 <i class="mx-2 fas fa-ban"></i>
                             </button>
                             <button onclick="handleServerDelete('{{ $server->id }}');" target="__blank"
                                 class="float-right mr-2 text-center btn btn-danger"
+                                {{ !$server->pterodactyl_id && $server->status !== 'failed' ? "disabled" : "" }}
                                 data-toggle="tooltip" data-placement="bottom" title="{{ __('Delete Server') }}">
                                 <i class="mx-2 fas fa-trash"></i>
                             </button>
                         </div>
                     </div>
-                 @endif
                 @endforeach
             </div>
             <!-- END CUSTOM CONTENT -->

--- a/themes/default/views/servers/index.blade.php
+++ b/themes/default/views/servers/index.blade.php
@@ -192,26 +192,25 @@
                         </div>
 
                         <div class="text-center card-footer">
-                            <a href="{{ $server->identifier ? $pterodactyl_url . '/server/' . $server->identifier : '#' }}"
-                                target="__blank"
+                            <a @if($server->identifier) href="{{ $pterodactyl_url . '/server/' . $server->identifier }}" target="_blank" @else tabindex="-1" aria-disabled="true" @endif
                                 class="float-left ml-2 text-center btn btn-info {{ !$server->identifier ? 'disabled' : '' }}"
                                 data-toggle="tooltip" data-placement="bottom" title="{{ __('Manage Server') }}">
                                 <i class="mx-2 fas fa-tools"></i>
                             </a>
-                            <a href="{{ $server->pterodactyl_id ? route('servers.show', ['server' => $server->id]) : '#' }}"
+                            <a @if($server->pterodactyl_id) href="{{ route('servers.show', ['server' => $server->id]) }}" @else tabindex="-1" aria-disabled="true" @endif
                             	class="mr-3 text-center btn btn-info {{ !$server->pterodactyl_id ? 'disabled' : '' }}"
                             	data-toggle="tooltip" data-placement="bottom" title="{{ __('Server Settings') }}">
                                 <i class="mx-2 fas fa-cog"></i>
                             </a>
-                            <button onclick="handleServerCancel('{{ $server->id }}');" target="__blank"
+                            <button onclick="handleServerCancel('{{ $server->id }}');"
                                 class="text-center btn btn-warning"
                                 {{ $server->suspended || $server->canceled || !$server->pterodactyl_id ? "disabled" : "" }}
                                 data-toggle="tooltip" data-placement="bottom" title="{{ __('Cancel Server') }}">
                                 <i class="mx-2 fas fa-ban"></i>
                             </button>
-                            <button onclick="handleServerDelete('{{ $server->id }}');" target="__blank"
+                            <button onclick="handleServerDelete('{{ $server->id }}');"
                                 class="float-right mr-2 text-center btn btn-danger"
-                                {{ !$server->pterodactyl_id && $server->status !== 'failed' ? "disabled" : "" }}
+                                {{ !$server->pterodactyl_id ? "disabled" : "" }}
                                 data-toggle="tooltip" data-placement="bottom" title="{{ __('Delete Server') }}">
                                 <i class="mx-2 fas fa-trash"></i>
                             </button>


### PR DESCRIPTION
<!--
  Before submitting, please make sure you have read CONTRIBUTING.md.
  Delete this comment block before submitting.

  Checklist:
  - Target branch is `development`, not `main`
  - Commit messages follow Conventional Commits
  - Code follows PSR-12
  - Self-review completed
-->

## Description

Quick and simple fix to the servers without pterodactyl_id assigned (for example if server creation failed for some reason) caused HTTP 500 on servers. This PR improves error handling coming from pterodactyl, as well as improves user interaction if server creation failed (he will be notified about server status, an will be able to contact admins to resolve the problem from their end). It also adds "Refund one billing period" checkbox during deletion by admin as an optional feature.

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor / code quality
- [ ] Documentation
- [ ] Other: <!-- describe -->

---

## Testing

Server creation tested with conditions when:
- required variable isn't set
- pterodactyl was offline
- pterodactyl returns 500

---

## AI Assistance

- [x] I used AI tools to assist with this contribution

---

## Checklist

- [x] My PR targets the `development` branch
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Code follows PSR-12
- [x] I have reviewed my own code
- [x] I have tested all affected functionality
- [x] No new warnings or errors introduced

---

## Legal

By submitting this pull request, I confirm that my contribution is made
under the terms of the project's
[Contributor License Agreement](https://github.com/Ctrlpanel-gg/panel/blob/development/CONTRIBUTOR_LICENSE_AGREEMENT)
and that I have read and agree to the
[Code of Conduct](https://github.com/Ctrlpanel-gg/panel/blob/development/.github/CODE_OF_CONDUCT.md).
