### PR TITLE
fix: stripe payments can fail due to payment amount rounding mismatch

### DIFF
--- a/app/Extensions/PaymentGateways/Stripe/StripeExtension.php
+++ b/app/Extensions/PaymentGateways/Stripe/StripeExtension.php
@@ -225,32 +225,15 @@ class StripeExtension extends PaymentExtension
     {
         $currency = strtoupper((string) ($paymentIntent->currency ?? ''));
         $expectedCurrency = strtoupper($payment->currency_code);
-        $amountInSmallestUnit = (int) ($paymentIntent->amount_received ?? $paymentIntent->amount ?? 0);
-        $amountInDatabaseUnits = self::convertGatewayAmountToDatabaseUnits($amountInSmallestUnit, $currency);
+        $amountReceived = (int) ($paymentIntent->amount_received ?? $paymentIntent->amount ?? 0);
+
+        $expectedAmount = self::convertAmount((float) $payment->total_price, $payment->currency_code);
 
         $isValid = $currency !== ''
             && $currency === $expectedCurrency
-            && $amountInDatabaseUnits === (int) $payment->total_price;
+            && $amountReceived === $expectedAmount;
 
         return $isValid;
-    }
-
-    protected static function convertGatewayAmountToDatabaseUnits(int $gatewayAmount, string $currency): int
-    {
-        $currency = strtoupper($currency);
-
-        if (in_array($currency, self::ZERO_DECIMAL_CURRENCIES, true)) {
-            $result = self::currencyHelper()->prepareForDatabase((float) $gatewayAmount);
-            return $result;
-        }
-
-        if (in_array($currency, self::THREE_DECIMAL_CURRENCIES, true)) {
-            $result = self::currencyHelper()->prepareForDatabase($gatewayAmount / 1000);
-            return $result;
-        }
-
-        $result = self::currencyHelper()->prepareForDatabase($gatewayAmount / 100);
-        return $result;
     }
 
     /**


### PR DESCRIPTION
<!--
  Before submitting, please make sure you have read CONTRIBUTING.md.
  Delete this comment block before submitting.

  Checklist:
  - Target branch is `development`, not `main`
  - Commit messages follow Conventional Commits
  - Code follows PSR-12
  - Self-review completed
-->

## Description

Fix for issue where Stripe payments was marked as cancelled even if they was processed due to payment amount rounding mismatch during validation

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Other: <!-- describe -->

---

## Testing

Stripe was tested with exact same settings as user that reported this issue has and no error appeared

---

## AI Assistance

- [ ] I used AI tools to assist with this contribution

---

## Checklist

- [x] My PR targets the `development` branch
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Code follows PSR-12
- [x] I have reviewed my own code
- [x] I have tested all affected functionality
- [x] No new warnings or errors introduced

---

## Legal

By submitting this pull request, I confirm that my contribution is made
under the terms of the project's
[Contributor License Agreement](https://github.com/Ctrlpanel-gg/panel/blob/development/CONTRIBUTOR_LICENSE_AGREEMENT)
and that I have read and agree to the
[Code of Conduct](https://github.com/Ctrlpanel-gg/panel/blob/development/.github/CODE_OF_CONDUCT.md).
