### PR TITLE
Fix server limit for product upgrades/downgrades

### DIFF
--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -388,6 +388,20 @@ class ServerController extends Controller
         ]);
     }
 
+    /**
+     * Determine whether the user has reached the per-product server limit.
+     */
+    private function productLimitReached(User $user, Product $product): bool
+    {
+        if ($product->serverlimit == 0) {
+            return false;
+        }
+
+        $productCount = $user->servers()->where('product_id', $product->id)->count();
+
+        return $productCount >= $product->serverlimit;
+    }
+
     private function getUpgradeOptions(Server $server, array $serverInfo): \Illuminate\Database\Eloquent\Collection
     {
         $currentProduct = Product::find($server->product_id);
@@ -422,8 +436,7 @@ class ServerController extends Controller
                 }
 
                 // Check server limit for the product
-                $productCount = $user->servers()->where("product_id", $product->id)->count();
-                if ($productCount >= $product->serverlimit && $product->serverlimit != 0) {
+                if ($this->productLimitReached($user, $product)) {
                     $product->doesNotFit = true;
                 }
 
@@ -456,12 +469,9 @@ class ServerController extends Controller
         }
 
         // Check server limit for the new product
-        if ($oldProduct->id !== $newProduct->id) {
-            $productCount = $user->servers()->where("product_id", $newProduct->id)->count();
-            if ($productCount >= $newProduct->serverlimit && $newProduct->serverlimit != 0) {
-                return redirect()->route('servers.show', ['server' => $server->id])
-                    ->with('error', __('You can not create any more Servers with this product!'));
-            }
+        if ($oldProduct->id !== $newProduct->id && $this->productLimitReached($user, $newProduct)) {
+            return redirect()->route('servers.show', ['server' => $server->id])
+                ->with('error', __('You can not create any more Servers with this product!'));
         }
 
         if (!$this->validateUpgrade($server, $oldProduct, $newProduct)) {
@@ -532,11 +542,8 @@ class ServerController extends Controller
         }
 
         // Check server limit for the new product
-        if ($oldProduct->id !== $newProduct->id) {
-            $productCount = $user->servers()->where("product_id", $newProduct->id)->count();
-            if ($productCount >= $newProduct->serverlimit && $newProduct->serverlimit != 0) {
-                return false;
-            }
+        if ($oldProduct->id !== $newProduct->id && $this->productLimitReached($user, $newProduct)) {
+            return false;
         }
 
         return true;

--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -396,6 +396,7 @@ class ServerController extends Controller
         $currentEgg = $serverInfo['egg'];
 
         //$currentProductEggs = $currentProduct->eggs->pluck('id')->toArray();
+        $user = Auth::user();
 
         return Product::orderBy('price', 'asc')
             ->with('nodes')->with('eggs')
@@ -406,7 +407,7 @@ class ServerController extends Controller
                 $builder->where('id', $currentEgg);
             })
             ->get()
-            ->map(function ($product) use ($currentProduct, $pteroNode) {
+            ->map(function ($product) use ($currentProduct, $pteroNode, $user) {
                 $product->eggs = $product->eggs->pluck('name')->toArray();
 
                 $memoryDiff = $product->memory - $currentProduct->memory;
@@ -417,6 +418,12 @@ class ServerController extends Controller
 
                 if ($memoryDiff > $maxMemory - $pteroNode['allocated_resources']['memory'] ||
                     $diskDiff > $maxDisk - $pteroNode['allocated_resources']['disk']) {
+                    $product->doesNotFit = true;
+                }
+
+                // Check server limit for the product
+                $productCount = $user->servers()->where("product_id", $product->id)->count();
+                if ($productCount >= $product->serverlimit && $product->serverlimit != 0) {
                     $product->doesNotFit = true;
                 }
 
@@ -446,6 +453,15 @@ class ServerController extends Controller
         if (!$newProduct) {
             return redirect()->route('servers.show', ['server' => $server->id])
                 ->with('error', __('Selected product not found'));
+        }
+
+        // Check server limit for the new product
+        if ($oldProduct->id !== $newProduct->id) {
+            $productCount = $user->servers()->where("product_id", $newProduct->id)->count();
+            if ($productCount >= $newProduct->serverlimit && $newProduct->serverlimit != 0) {
+                return redirect()->route('servers.show', ['server' => $server->id])
+                    ->with('error', __('You can not create any more Servers with this product!'));
+            }
         }
 
         if (!$this->validateUpgrade($server, $oldProduct, $newProduct)) {
@@ -513,6 +529,14 @@ class ServerController extends Controller
         $refundAmount = $this->calculateRefund($server, $oldProduct);
         if ($user->credits < ($newProduct->price - $refundAmount)) {
             return false;
+        }
+
+        // Check server limit for the new product
+        if ($oldProduct->id !== $newProduct->id) {
+            $productCount = $user->servers()->where("product_id", $newProduct->id)->count();
+            if ($productCount >= $newProduct->serverlimit && $newProduct->serverlimit != 0) {
+                return false;
+            }
         }
 
         return true;


### PR DESCRIPTION
## Description

Fixed server limit feature for product upgrades/downgrades. When a product has a serverlimit set (non-zero), users was able upgrade/downgrade to the product that already reached its limit for user.

### Changes:

* Added server limit validation when listing available upgrade products
* Added server limit validation when upgrading a server to a different product
* Added server limit validation in the `validateUpgrade` method

## Type of Change

* [x] Bug fix

## Testing

* [x] Tested creating a server when product limit is reached (should show error)
* [x] Tested upgrading to a product that has reached its limit (should show error)
* [x] Tested that products with `serverlimit = 0` (unlimited) work as before
* [x] Tested that upgrading to the same product doesn't trigger limit check
* [x] Verified upgrade product list correctly marks limited products as "doesNotFit"

## AI Assistance

* [ ] I used AI tools to assist with this contribution

## Checklist

* [x] My PR targets the development branch
* [x] Commit messages follow Conventional Commits
* [x] I have reviewed my own code
* [x] I have tested all affected functionality
* [x] No new warnings or errors introduced