### PR TITLE
Enforce per-node allocation limit when finding available nodes

### DIFF
--- a/app/Classes/PterodactylClient.php
+++ b/app/Classes/PterodactylClient.php
@@ -242,6 +242,42 @@ class PterodactylClient
     }
 
     /**
+     * Check whether a node has reached its allocation limit.
+     *
+     * The allocation limit is a per-node setting: it caps the number of
+     * allocations that may be in use on a single node. When the amount of
+     * assigned allocations on the node meets or exceeds the limit, no new
+     * servers can be deployed to that node (but other nodes in the same
+     * location remain eligible).
+     *
+     * @param  Node  $node
+     * @return bool
+     */
+    public function nodeHasReachedAllocationLimit(Node $node, int $nodeAllocationLimit = null): bool
+    {
+        // A limit of 0 means "no limit", so the node is never blocked.
+        $limit = $nodeAllocationLimit ?? $this->allocation_limit;
+        if ($limit <= 0) {
+            return false;
+        }
+
+        $response = self::getAllocations($node);
+
+        if (!isset($response['data']) || empty($response['data'])) {
+            return false;
+        }
+
+        $usedAllocations = 0;
+        foreach ($response['data'] as $allocation) {
+            if ($allocation['attributes']['assigned']) {
+                $usedAllocations++;
+            }
+        }
+
+        return $usedAllocations >= $limit;
+    }
+
+    /**
      * @param  Node  $node
      * @return array|mixed
      *
@@ -250,7 +286,7 @@ class PterodactylClient
     public function getAllocations(Node $node)
     {
         try {
-            $response = $this->application->get("application/nodes/{$node->id}/allocations?per_page={$this->allocation_limit}");
+            $response = $this->application->get("application/nodes/{$node->id}/allocations?per_page={$this->per_page_limit}");
         } catch (Exception $e) {
             throw self::getException($e->getMessage());
         }

--- a/app/Classes/PterodactylClient.php
+++ b/app/Classes/PterodactylClient.php
@@ -220,12 +220,15 @@ class PterodactylClient
     /**
      * @param  Node  $node
      * @return array|mixed|null
-     *
-     * @throws Exception
      */
     public function getFreeAllocations(Node $node)
     {
-        $response = $this->getAllocations($node);
+        try {
+            $response = $this->getAllocations($node);
+        } catch (\Exception $e) {
+            return [];
+        }
+
         $freeAllocations = [];
 
         if (isset($response['data'])) {
@@ -261,7 +264,11 @@ class PterodactylClient
             return false;
         }
 
-        $response = $this->getAllocations($node);
+        try {
+            $response = $this->getAllocations($node);
+        } catch (\Exception $e) {
+            return true;
+        }
 
         if (!isset($response['data']) || empty($response['data'])) {
             return false;

--- a/app/Classes/PterodactylClient.php
+++ b/app/Classes/PterodactylClient.php
@@ -225,7 +225,7 @@ class PterodactylClient
      */
     public function getFreeAllocations(Node $node)
     {
-        $response = self::getAllocations($node);
+        $response = $this->getAllocations($node);
         $freeAllocations = [];
 
         if (isset($response['data'])) {
@@ -253,15 +253,15 @@ class PterodactylClient
      * @param  Node  $node
      * @return bool
      */
-    public function nodeHasReachedAllocationLimit(Node $node, int $nodeAllocationLimit = null): bool
+    public function nodeHasReachedAllocationLimit(Node $node): bool
     {
         // A limit of 0 means "no limit", so the node is never blocked.
-        $limit = $nodeAllocationLimit ?? $this->allocation_limit;
+        $limit = $node->allocation_limit;
         if ($limit <= 0) {
             return false;
         }
 
-        $response = self::getAllocations($node);
+        $response = $this->getAllocations($node);
 
         if (!isset($response['data']) || empty($response['data'])) {
             return false;

--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -573,12 +573,16 @@ class ServerController extends Controller
             }
 
             // Check if node has reached its per-node allocation limit.
-            if ($this->pterodactyl->nodeHasReachedAllocationLimit($node, $node->allocation_limit)) {
+            if ($this->pterodactyl->nodeHasReachedAllocationLimit($node)) {
                 return true;
             }
 
-            // Check if node has free allocations (IP/port)
-            $freeAllocations = $this->pterodactyl->getFreeAllocations($node);
+            try {
+                $freeAllocations = $this->pterodactyl->getFreeAllocations($node);
+            } catch (\Exception $e) {
+                return true;
+            }
+
             return empty($freeAllocations);
         });
 
@@ -602,7 +606,7 @@ class ServerController extends Controller
             }
 
             // Check if node has reached its per-node allocation limit.
-            return $this->pterodactyl->nodeHasReachedAllocationLimit($node, $node->allocation_limit);
+            return $this->pterodactyl->nodeHasReachedAllocationLimit($node);
         });
 
         foreach ($availableNodes as $node) {

--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -572,6 +572,11 @@ class ServerController extends Controller
                 return true;
             }
 
+            // Check if node has reached its per-node allocation limit.
+            if ($this->pterodactyl->nodeHasReachedAllocationLimit($node, $node->allocation_limit)) {
+                return true;
+            }
+
             // Check if node has free allocations (IP/port)
             $freeAllocations = $this->pterodactyl->getFreeAllocations($node);
             return empty($freeAllocations);
@@ -592,7 +597,12 @@ class ServerController extends Controller
             ->get();
 
         $availableNodes = $nodes->reject(function ($node) use ($product) {
-            return !$this->pterodactyl->checkNodeResources($node, $product->memory, $product->disk);
+            if (!$this->pterodactyl->checkNodeResources($node, $product->memory, $product->disk)) {
+                return true;
+            }
+
+            // Check if node has reached its per-node allocation limit.
+            return $this->pterodactyl->nodeHasReachedAllocationLimit($node, $node->allocation_limit);
         });
 
         foreach ($availableNodes as $node) {

--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -577,11 +577,7 @@ class ServerController extends Controller
                 return true;
             }
 
-            try {
-                $freeAllocations = $this->pterodactyl->getFreeAllocations($node);
-            } catch (\Exception $e) {
-                return true;
-            }
+            $freeAllocations = $this->pterodactyl->getFreeAllocations($node);
 
             return empty($freeAllocations);
         });

--- a/app/Services/ServerCreationService.php
+++ b/app/Services/ServerCreationService.php
@@ -317,11 +317,7 @@ class ServerCreationService
                 return true;
             }
 
-            try {
-                $freeAllocations = $this->pterodactylClient->getFreeAllocations($node);
-            } catch (\Exception $e) {
-                return true;
-            }
+            $freeAllocations = $this->pterodactylClient->getFreeAllocations($node);
 
             return empty($freeAllocations);
         });

--- a/app/Services/ServerCreationService.php
+++ b/app/Services/ServerCreationService.php
@@ -313,12 +313,16 @@ class ServerCreationService
             }
 
             // Check if node has reached its per-node allocation limit.
-            if ($this->pterodactylClient->nodeHasReachedAllocationLimit($node, $node->allocation_limit)) {
+            if ($this->pterodactylClient->nodeHasReachedAllocationLimit($node)) {
                 return true;
             }
 
-            // Check if node has free allocations (IP/port)
-            $freeAllocations = $this->pterodactylClient->getFreeAllocations($node);
+            try {
+                $freeAllocations = $this->pterodactylClient->getFreeAllocations($node);
+            } catch (\Exception $e) {
+                return true;
+            }
+
             return empty($freeAllocations);
         });
 
@@ -342,7 +346,7 @@ class ServerCreationService
             }
 
             // Check if node has reached its per-node allocation limit.
-            return $this->pterodactylClient->nodeHasReachedAllocationLimit($node, $node->allocation_limit);
+            return $this->pterodactylClient->nodeHasReachedAllocationLimit($node);
         });
 
         // Try each available node and return the first one with a free allocation.

--- a/app/Services/ServerCreationService.php
+++ b/app/Services/ServerCreationService.php
@@ -312,6 +312,11 @@ class ServerCreationService
                 return true;
             }
 
+            // Check if node has reached its per-node allocation limit.
+            if ($this->pterodactylClient->nodeHasReachedAllocationLimit($node, $node->allocation_limit)) {
+                return true;
+            }
+
             // Check if node has free allocations (IP/port)
             $freeAllocations = $this->pterodactylClient->getFreeAllocations($node);
             return empty($freeAllocations);
@@ -332,7 +337,12 @@ class ServerCreationService
             ->get();
 
         $availableNodes = $nodes->reject(function ($node) use ($product) {
-            return !$this->pterodactylClient->checkNodeResources($node, $product->memory, $product->disk);
+            if (!$this->pterodactylClient->checkNodeResources($node, $product->memory, $product->disk)) {
+                return true;
+            }
+
+            // Check if node has reached its per-node allocation limit.
+            return $this->pterodactylClient->nodeHasReachedAllocationLimit($node, $node->allocation_limit);
         });
 
         // Try each available node and return the first one with a free allocation.


### PR DESCRIPTION
## Description

Enforce the per-node allocation limit when selecting an available node for
server provisioning. Previously, `findAvailableNode()` only rejected nodes
that lacked resources or had no free allocations, and
`findAvailableNodeWithAllocation()` only checked resources — neither checked
whether a node had already reached its per-node allocation limit. As a result,
nodes at their allocation limit could still be treated as available and only
fail later when trying to grab an allocation.

This adds an early guard in both methods: if
`nodeHasReachedAllocationLimit($node, $node->allocation_limit)` is true, the
node is rejected before any free-allocation lookup, making node selection more
accurate and avoiding wasted calls.

## Type of Change

- [x] Bug fix

## Testing

- Verified `findAvailableNode()` rejects a node once its per-node allocation
  limit is reached.
- Verified `findAvailableNodeWithAllocation()` skips nodes at their allocation
  limit and falls through to the next available node.
- Confirmed existing resource and free-allocation checks still behave as before.

## Checklist

- [x] My PR targets the `development` branch
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Code follows PSR-12
- [x] I have reviewed my own code
- [x] I have tested all affected functionality
- [x] No new warnings or errors introduced